### PR TITLE
Implement real-time lattice rendering with OpenGL and uniformize lattice size settings in the backend

### DIFF
--- a/.github/workflows/qt-linux.yml
+++ b/.github/workflows/qt-linux.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
-        version: '5.12.8'
+        version: '5.14.0'
         host: 'linux'
         target: 'desktop'
         modules: 'quick core qml gui'

--- a/.github/workflows/qt-linux.yml
+++ b/.github/workflows/qt-linux.yml
@@ -20,7 +20,7 @@ jobs:
         version: '5.12.8'
         host: 'linux'
         target: 'desktop'
-        modules: 'quick core'
+        modules: 'quick core qml gui'
     - name: qmake
       run: qmake .
     - name: make

--- a/.github/workflows/qt-macos.yml
+++ b/.github/workflows/qt-macos.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
-        version: '5.12.8'
+        version: '5.14.0'
         host: 'mac'
         target: 'desktop'
         modules: 'quick core qml gui'

--- a/.github/workflows/qt-macos.yml
+++ b/.github/workflows/qt-macos.yml
@@ -20,7 +20,7 @@ jobs:
         version: '5.12.8'
         host: 'mac'
         target: 'desktop'
-        modules: 'quick core'
+        modules: 'quick core qml gui'
     - name: qmake
       run: qmake .
     - name: make

--- a/.github/workflows/qt-windows.yml
+++ b/.github/workflows/qt-windows.yml
@@ -21,7 +21,7 @@ jobs:
         host: 'windows'
         target: 'desktop'
         arch: 'win64_mingw73'
-        modules: 'quick core'
+        modules: 'quick core qml gui'
     - name: qmake
       run: qmake .
     - name: make

--- a/.github/workflows/qt-windows.yml
+++ b/.github/workflows/qt-windows.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
-        version: '5.12.8'
+        version: '5.14.0'
         host: 'windows'
         target: 'desktop'
         arch: 'win64_mingw73'

--- a/autonomx/AppModel.cpp
+++ b/autonomx/AppModel.cpp
@@ -267,21 +267,11 @@ bool AppModel::validateNewGeneratorName(QString name) {
 }
 
 Generator* AppModel::getGenerator(int id) const {
-    for(QList<QSharedPointer<Generator>>::iterator it = generatorsList->begin(); it != generatorsList->end(); it++) {
-        if(id == (*it)->getID()) {
-            return (*it).data();
-        }
-     }
-    return nullptr;
+    return generatorsHashMap->value(id).data();
 }
 
 GeneratorFacade* AppModel::getGeneratorFacade(int id) const {
-    for(QList<QSharedPointer<GeneratorFacade>>::iterator it = generatorFacadesList->begin(); it != generatorFacadesList->end(); it++) {
-        if(id == (*it)->value("id").toInt()) {
-            return (*it).data();
-        }
-     }
-    return nullptr;
+    return generatorFacadesHashMap->value(id).data();
 }
 
 GeneratorModel* AppModel::getGeneratorModel() const {

--- a/autonomx/AppModel.h
+++ b/autonomx/AppModel.h
@@ -51,8 +51,12 @@ private:
     void operator=(AppModel const&) = delete;   // prevent assignment
 
     // data (lists)
-    QSharedPointer<QList<QSharedPointer<Generator>>> generators;
-    QSharedPointer<QList<QSharedPointer<GeneratorFacade>>> generatorFacades;
+    QSharedPointer<QList<QSharedPointer<Generator>>> generatorsList;
+    QSharedPointer<QList<QSharedPointer<GeneratorFacade>>> generatorFacadesList;
+
+    // data (hash maps)
+    QSharedPointer<QHash<int, QSharedPointer<Generator>>> generatorsHashMap;
+    QSharedPointer<QHash<int, QSharedPointer<GeneratorFacade>>> generatorFacadesHashMap;
 
     // data (unique elements)
     QSharedPointer<GeneratorModel> generatorModel;

--- a/autonomx/AppModel.h
+++ b/autonomx/AppModel.h
@@ -33,7 +33,6 @@ public:
         static AppModel instance;
         return instance;
     }
-    void start();
     QThread*            getComputeThread() const;           // needed to exit the thread at app quit. we can only connect this from the main.
     QThread*            getOscThread() const;               // needed to exit the thread at app quit. we can only connect this from the main.
     ComputeEngine*      getComputeEngine() const;           // needed for connections
@@ -70,6 +69,17 @@ private:
     QSharedPointer<QThread> oscThread;
 
     // utility variables
-    bool started = false;
     bool flagDebug = false;
+signals:
+    // connects to ComputeEngine::addGenerator for safe addition of generators to data structures
+    void addGenerator(QSharedPointer<Generator> generator);
+
+    // connects to ComputeEngine::removeGenerator for safe removal of generators from data structures
+    void removeGenerator(QSharedPointer<Generator> generator);
+
+    // connects to OscEngine::startGeneratorOsc for safe start of osc processing
+    void startGeneratorOsc(QSharedPointer<Generator> generator);
+
+    // connects to OscEngine::stopGeneratorOsc for safe stop of osc processing
+    void stopGeneratorOsc(QSharedPointer<Generator> generator);
 };

--- a/autonomx/ComputeEngine.cpp
+++ b/autonomx/ComputeEngine.cpp
@@ -181,6 +181,8 @@ void ComputeEngine::loop() {
 void ComputeEngine::addGenerator(QSharedPointer<Generator> generator) {
     // add to list
     generators->append(generator);
+    // add to hash map
+    generatorsHashMap->insert(generator->getID(), generator);
 
     int id = generator->getID();
     QString addressReceiver = generator->getOscInputAddress();
@@ -239,6 +241,11 @@ void ComputeEngine::deleteGenerator(int id) {
         if(id == (*it)->getID()) {
             // erase from the list
             generators->erase(it);
+            // erase from the hash map
+            bool success = generatorsHashMap->remove(id);
+            if(!success) {
+                throw std::runtime_error("generator does not exist");
+            }
             // delete osc sender and receiver
             emit deleteOscReceiver(id);
             emit deleteOscSender(id);

--- a/autonomx/ComputeEngine.cpp
+++ b/autonomx/ComputeEngine.cpp
@@ -63,7 +63,7 @@ void ComputeEngine::receiveOscData(int id, QVariantList data) {
         if(i < data.size()) {
             // check the message's type can be cast to double
             QMetaType::Type type = (QMetaType::Type) dataAsList.at(i).type();
-            if(type == QMetaType::Float || QMetaType::Double || QMetaType::Int || QMetaType::Long) {
+            if(type == QMetaType::Float || type == QMetaType::Double || type == QMetaType::Int || type == QMetaType::Long) {
                 input = dataAsList.at(i).toDouble();
                 argumentsValid++;
             }

--- a/autonomx/ComputeEngine.h
+++ b/autonomx/ComputeEngine.h
@@ -28,7 +28,7 @@
 class ComputeEngine : public QObject {
     Q_OBJECT
 private:
-    QSharedPointer<QList<QSharedPointer<Generator>>> generators;
+    QSharedPointer<QList<QSharedPointer<Generator>>> generatorsList;
     QSharedPointer<QHash<int, QSharedPointer<Generator>>> generatorsHashMap;
     QElapsedTimer elapsedTimer;
     double frequency = 60;
@@ -41,7 +41,7 @@ private:
     std::mt19937 randomGenerator;
 std::uniform_real_distribution<> randomUniform;
 public:
-    ComputeEngine(QSharedPointer<QList<QSharedPointer<Generator>>> generators);
+    ComputeEngine(QSharedPointer<QList<QSharedPointer<Generator>>> generatorsList, QSharedPointer<QHash<int, QSharedPointer<Generator>>> generatorsHashMap);
     ~ComputeEngine();
 signals:
     void sendOscData(int id, QVariantList data);

--- a/autonomx/ComputeEngine.h
+++ b/autonomx/ComputeEngine.h
@@ -44,21 +44,21 @@ public:
     ComputeEngine(QSharedPointer<QList<QSharedPointer<Generator>>> generatorsList, QSharedPointer<QHash<int, QSharedPointer<Generator>>> generatorsHashMap);
     ~ComputeEngine();
 signals:
+    // sends data through OscEngine::sendOscData
     void sendOscData(int id, QVariantList data);
-
-    void createOscReceiver(int id, QString address, int port);
-    void updateOscReceiver(int id, QString address, int port);
-    void deleteOscReceiver(int id);
-
-    void createOscSender(int id, QString addressHost, QString addressTarget, int port);
-    void updateOscSender(int id, QString addressHost, QString addressTarget, int port);
-    void deleteOscSender(int id);
 public slots:
+    // handles data received from OscEngine::receiveOscData
+    void receiveOscData(int id, QVariantList data);
+
+    // adds a generator to the list and hash map
+    void addGenerator(QSharedPointer<Generator> generator);
+
+    // removes a generator from the list and hash map
+    void removeGenerator(QSharedPointer<Generator> generator);
+
+    // starts the compute loop
     void start();
+
+    // does the computation and schedules itself for the next iteration
     void loop();
-
-    void recieveOscData(int id, QVariantList data);
-
-    void addGenerator(QSharedPointer<Generator>);
-    void deleteGenerator(int id);
 };

--- a/autonomx/Generator.cpp
+++ b/autonomx/Generator.cpp
@@ -348,6 +348,8 @@ void Generator::writeLatticeData(double** latticeData, int* allocatedWidth, int*
 
         // check if anything is allocated
         if(latticeData == nullptr) {
+            // nothing is allocated yet
+            latticeData = new double*;
             *latticeData = new double[latticeWidth * latticeHeight];
         } else {
             // check if the the right amount of memory is allocated
@@ -371,7 +373,7 @@ void Generator::writeLatticeData(double** latticeData, int* allocatedWidth, int*
         // we are done; release the mutex
         latticeDataMutex.unlock();
 
-        // we are done; tell the GeneratorLatticeRenderer
+        // we are done; tell the GeneratorLatticeCommunicator
         emit writeLatticeDataCompleted();
     }
 }

--- a/autonomx/Generator.cpp
+++ b/autonomx/Generator.cpp
@@ -365,7 +365,7 @@ void Generator::writeLatticeData(float** latticeData, int* allocatedWidth, int* 
             // the amount of allocated memory mismatches the required amount, must reallocate
 
             // make sure this is not the first function call; in that case we can't safely delete since the pointer is uninitialized
-            if(*allocatedWidth != 0 && *allocatedHeight != 0) {
+            if(*latticeData != nullptr) {
                 delete[] *latticeData;
             }
 

--- a/autonomx/Generator.cpp
+++ b/autonomx/Generator.cpp
@@ -365,7 +365,13 @@ void Generator::writeLatticeData(float** latticeData, int* allocatedWidth, int* 
         // check if the the right amount of memory is allocated
         if((*allocatedWidth) * (*allocatedHeight) != latticeWidth * latticeHeight) {
             // the amount of allocated memory mismatches the required amount, must reallocate
-            delete[] *latticeData;
+
+            // make sure this is not the first function call; in that case we can't safely delete since the pointer is uninitialized
+            if(*allocatedWidth != 0 && *allocatedHeight != 0) {
+                delete[] *latticeData;
+            }
+
+            // allocate the memory
             *latticeData = new float[latticeWidth * latticeHeight];
         }
 
@@ -397,13 +403,6 @@ void Generator::writeLatticeData(float** latticeData, int* allocatedWidth, int* 
 }
 
 void Generator::allocateInitialLatticeData(float** latticeData, int* allocatedWidth, int* allocatedHeight) {
-    latticeDataMutex.lock();
-
-    *latticeData = new float[latticeWidth * latticeHeight];
-
-    latticeDataMutex.unlock();
-}
-
 void Generator::lockLatticeDataMutex() {
     latticeDataMutex.lock();
 }

--- a/autonomx/Generator.cpp
+++ b/autonomx/Generator.cpp
@@ -292,10 +292,9 @@ void Generator::writeLatticeWidth(int latticeWidth) {
         qDebug() << "writeLatticeWidth\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\t value = " << latticeWidth;
     }
 
-    // actually do the changes in the derived algorithm
+    // actually do the changes in the derived class
     writeLatticeWidthDelegate(latticeWidth);
 
-    this->latticeWidth = latticeWidth;
     emit valueChanged("latticeWidth", latticeWidth);
     emit latticeWidthChanged(latticeWidth);
 }
@@ -313,10 +312,9 @@ void Generator::writeLatticeHeight(int latticeHeight) {
         qDebug() << "writeLatticeHeight\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\t value = " << latticeHeight;
     }
 
-    // actually do the changes in the derived algorithm
+    // actually do the changes in the derived class
     writeLatticeHeightDelegate(latticeHeight);
 
-    this->latticeHeight = latticeHeight;
     emit valueChanged("latticeHeight", latticeHeight);
     emit latticeHeightChanged(latticeHeight);
 }

--- a/autonomx/Generator.cpp
+++ b/autonomx/Generator.cpp
@@ -402,7 +402,6 @@ void Generator::writeLatticeData(float** latticeData, int* allocatedWidth, int* 
     }
 }
 
-void Generator::allocateInitialLatticeData(float** latticeData, int* allocatedWidth, int* allocatedHeight) {
 void Generator::lockLatticeDataMutex() {
     latticeDataMutex.lock();
 }

--- a/autonomx/Generator.h
+++ b/autonomx/Generator.h
@@ -114,7 +114,7 @@ public:
     //
     //    flattenedData[index] = latticeData[index % latticeWidth, index / latticeWidth]
     //
-    virtual void writeLatticeDataDelegate(double* latticeData) = 0;
+    virtual void writeLatticeDataDelegate(float* latticeData) = 0;
 private:
     int id;                                     // generator id, generated automatically by ComputeEngine in constructor
 
@@ -152,15 +152,17 @@ public slots:
     // both are passed by pointer so that GeneratorLatticeRenderer can keep track of the new size after this method is executed.
     // why not just use a getter before the method call? because we want this to be atomic; things could get changed between the getter call and the method call.
     //
-    // the first call to this method is done with a null pointer. the method then allocates an initial block of memory.
-    //
     // this method must never be executed while GeneratorLatticeRenderer's render method is using **latticeData. it uses latticeDataMutex to prevent this.
     // if GeneratorLatticeRenderer's render has already locked latticeDataMutex, we schedule the method call to happen at a later time so that the ComputeEngine does not lock
     // we need a mechanism to prevent duplicate requests that would happen if the method is unable to complete before the next render frame however...
     // this is done by emitting writeLatticeDataCompleted once done, and only allowing GeneratorLatticeRenderer to emit writeLatticeData signals if the previous one did complete.
     //
     // the connection from GeneratorLatticeCommunicator's requestLatticeData signal to Generator's writeLatticeData slot is created from GeneratorLatticeCommunicator
-    void writeLatticeData(double** latticeData, int* allocatedWidth, int* allocatedHeight);
+    void writeLatticeData(float** latticeData, int* allocatedWidth, int* allocatedHeight);
+
+    // this does the initial memory allocation for latticeData
+    void allocateInitialLatticeData(float** latticeData, int* allocatedWidth, int* allocatedHeight);
+
 signals:
     // common signal used alongside all other property change signals. allows the Facade class to work properly
     // (for connection to QQmlPropertyMap's updateValue slot)

--- a/autonomx/Generator.h
+++ b/autonomx/Generator.h
@@ -141,7 +141,7 @@ public slots:
     // (for connection from QQmlPropertyMap's valueChanged signal)
     void updateValue(const QString &key, const QVariant &value);
 
-    // slot used by GeneratorLatticeRenderer to get the lattice data.
+    // slot used by GeneratorLatticeCommunicator to get the lattice data.
     //
     // latticeData is a pointer to a pointer which designates the block of memory data is written to.
     // preAllocatedSize represents the amount of allocated memory at *latticeData before the function call
@@ -159,7 +159,7 @@ public slots:
     // we need a mechanism to prevent duplicate requests that would happen if the method is unable to complete before the next render frame however...
     // this is done by emitting writeLatticeDataCompleted once done, and only allowing GeneratorLatticeRenderer to emit writeLatticeData signals if the previous one did complete.
     //
-    // the connection from GeneratorLatticeRenderer's writeLatticeData signal to Generator's writeLatticeData slot is created from GeneratorLatticeRenderer
+    // the connection from GeneratorLatticeCommunicator's requestLatticeData signal to Generator's writeLatticeData slot is created from GeneratorLatticeCommunicator
     void writeLatticeData(double** latticeData, int* allocatedWidth, int* allocatedHeight);
 signals:
     // common signal used alongside all other property change signals. allows the Facade class to work properly
@@ -182,8 +182,8 @@ signals:
     void latticeWidthChanged(int latticeWidth);
     void latticeHeightChanged(int latticeHeight);
 
-    // tells the GeneratorLatticeRenderer that the previously created writeLatticeData request is completed, and that a new one can be started at the end of the current render frame.
+    // tells the GeneratorLatticeCommunicator that the previously created writeLatticeData request is completed, and that a new one can be started at the end of the current render frame.
     //
-    // the connections from Generator's writeLatticeDataCompleted signal to GeneratorLatticeRenderer's writeLatticeDataCompleted slot is created from GeneratorLatticeRenderer
+    // the connections from Generator's writeLatticeDataCompleted signal to GeneratorLatticeCommunicator's requestLatticeDataCompleted slot is created from GeneratorLatticeCommunicator
     void writeLatticeDataCompleted();
 };

--- a/autonomx/Generator.h
+++ b/autonomx/Generator.h
@@ -157,12 +157,10 @@ public slots:
     // we need a mechanism to prevent duplicate requests that would happen if the method is unable to complete before the next render frame however...
     // this is done by emitting writeLatticeDataCompleted once done, and only allowing GeneratorLatticeRenderer to emit writeLatticeData signals if the previous one did complete.
     //
+    // the first call to this function is done with latticeData as a new float pointer pointer that is not null, and with allocatedWidth and allocatedHeight as 0. the memory for the inner pointer will be allocated automatically
+    //
     // the connection from GeneratorLatticeCommunicator's requestLatticeData signal to Generator's writeLatticeData slot is created from GeneratorLatticeCommunicator
     void writeLatticeData(float** latticeData, int* allocatedWidth, int* allocatedHeight);
-
-    // this does the initial memory allocation for latticeData
-    void allocateInitialLatticeData(float** latticeData, int* allocatedWidth, int* allocatedHeight);
-
 signals:
     // common signal used alongside all other property change signals. allows the Facade class to work properly
     // (for connection to QQmlPropertyMap's updateValue slot)

--- a/autonomx/Generator.h
+++ b/autonomx/Generator.h
@@ -97,8 +97,7 @@ public:
     void writeLatticeHeight(int latticeHeight);
 
     // these are implemented by the derived class and take care of any memory reallocation needed to change the size of the algorithm.
-    // this is called by writeLatticeWidth / writeLatticeHeight before the value is actually changed. the value passed is the new one.
-    // once this is done, writeLatticeWidth / writeLatticeHeight will take care of writing the proper value.
+    // this is called by writeLatticeWidth / writeLatticeHeight. this must set the variable to the passed value.
     virtual void writeLatticeWidthDelegate(int latticeWidth) = 0;
     virtual void writeLatticeHeightDelegate(int latticeHeight) = 0;
 
@@ -115,6 +114,9 @@ public:
     //    flattenedData[index] = latticeData[index % latticeWidth, index / latticeWidth]
     //
     virtual void writeLatticeDataDelegate(float* latticeData) = 0;
+protected:
+    int latticeWidth = 20;                      // lattice width
+    int latticeHeight = 20;                     // lattice height
 private:
     int id;                                     // generator id, generated automatically by ComputeEngine in constructor
 
@@ -129,9 +131,6 @@ private:
     int oscOutputPort = 6669;                   // generator osc output port, assigned by user
     QString oscOutputAddressHost = "127.0.0.1"; // generator osc output address for host, assigned by user (this is an ip)
     QString oscOutputAddressTarget = "/output"; // generator osc output address for target, assigned by user (this is an osc destination)
-
-    int latticeWidth = 20;                      // lattice width
-    int latticeHeight = 20;                     // lattice height
 
     bool flagDebug = false;                     // enables debug
 

--- a/autonomx/GeneratorLattice.cpp
+++ b/autonomx/GeneratorLattice.cpp
@@ -1,0 +1,38 @@
+// Copyright 2020, Xmodal
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "GeneratorLattice.h"
+#include <QDebug>
+
+QQuickFramebufferObject::Renderer * GeneratorLattice::createRenderer() const {
+    connect(this, &GeneratorLattice::visibleChanged, this, &QQuickFramebufferObject::update);
+    QQuickFramebufferObject::Renderer * renderer = new GeneratorLatticeRenderer();
+    return renderer;
+}
+
+int GeneratorLattice::getGeneratorID() {
+    return generatorID;
+}
+
+void GeneratorLattice::writeGeneratorID(int generatorID) {
+    if(this->generatorID == generatorID) {
+        return;
+    }
+
+    qDebug() << "generator ID changed: " << generatorID;
+
+    this->generatorID = generatorID;
+    emit generatorIDChanged(generatorID);
+}

--- a/autonomx/GeneratorLattice.h
+++ b/autonomx/GeneratorLattice.h
@@ -1,0 +1,33 @@
+// Copyright 2020, Xmodal
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <QQuickFramebufferObject>
+#include "GeneratorLatticeRenderer.h"
+
+class GeneratorLattice : public QQuickFramebufferObject {
+    Q_OBJECT
+    QML_ELEMENT
+    Q_PROPERTY(int generatorID READ getGeneratorID WRITE writeGeneratorID NOTIFY generatorIDChanged)
+public:
+    QQuickFramebufferObject::Renderer * createRenderer() const;
+    int getGeneratorID();
+    void writeGeneratorID(int generatorID);
+signals:
+    void generatorIDChanged(int generatorID);
+private:
+    int generatorID;
+};

--- a/autonomx/GeneratorLattice.h
+++ b/autonomx/GeneratorLattice.h
@@ -20,7 +20,6 @@
 
 class GeneratorLattice : public QQuickFramebufferObject {
     Q_OBJECT
-    QML_ELEMENT
     Q_PROPERTY(int generatorID READ getGeneratorID WRITE writeGeneratorID NOTIFY generatorIDChanged)
 public:
     QQuickFramebufferObject::Renderer * createRenderer() const;

--- a/autonomx/GeneratorLatticeCommunicator.cpp
+++ b/autonomx/GeneratorLatticeCommunicator.cpp
@@ -1,0 +1,50 @@
+// Copyright 2020, Xmodal
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "GeneratorLatticeCommunicator.h"
+
+GeneratorLatticeCommunicator::GeneratorLatticeCommunicator() {}
+
+void GeneratorLatticeCommunicator::updateGenerator(Generator *generator) {
+    if(this->generator == nullptr) {
+        // no previous connections to delete
+    } else {
+        // previous connections must be deleted
+        disconnect(connectionRequestLatticeData);
+        disconnect(connectionRequestLatticeDataCompleted);
+    }
+    this->generator = generator;
+
+    connectionRequestLatticeData = connect(this, &GeneratorLatticeCommunicator::requestLatticeData, generator, &Generator::writeLatticeData);
+    connectionRequestLatticeDataCompleted = connect(generator, &Generator::writeLatticeDataCompleted, this, &GeneratorLatticeCommunicator::requestLatticeDataCompleted);
+}
+
+void GeneratorLatticeCommunicator::writeLatticeData(double** latticeData, int* allocatedWidth, int* allocatedHeight) {
+    currentRequestDone = false;
+    emit requestLatticeData(latticeData, allocatedWidth, allocatedHeight);
+}
+
+void GeneratorLatticeCommunicator::requestLatticeDataCompleted() {
+    currentRequestDone = true;
+    firstRequestDone = true;
+}
+
+bool GeneratorLatticeCommunicator::isCurrentRequestDone() {
+    return currentRequestDone;
+}
+
+bool GeneratorLatticeCommunicator::isFirstRequestDone() {
+    return firstRequestDone;
+}

--- a/autonomx/GeneratorLatticeCommunicator.cpp
+++ b/autonomx/GeneratorLatticeCommunicator.cpp
@@ -26,13 +26,11 @@ void GeneratorLatticeCommunicator::updateGenerator(Generator *generator) {
         // no previous connections to delete
     } else {
         // previous connections must be deleted
-        disconnect(connectionAllocateInitialLatticeData);
         disconnect(connectionWriteLatticeData);
         disconnect(connectionWriteLatticeDataCompleted);
     }
     this->generator = generator;
 
-    connectionAllocateInitialLatticeData = connect(this, &GeneratorLatticeCommunicator::allocateInitialLatticeDataHandler, generator, &Generator::allocateInitialLatticeData);
     connectionWriteLatticeData = connect(this, &GeneratorLatticeCommunicator::writeLatticeDataHandler, generator, &Generator::writeLatticeData);
     connectionWriteLatticeDataCompleted = connect(generator, &Generator::writeLatticeDataCompleted, this, &GeneratorLatticeCommunicator::requestLatticeDataCompleted);
 }
@@ -42,10 +40,6 @@ void GeneratorLatticeCommunicator::writeLatticeData(float** latticeData, int* al
         qDebug() << "writeLatticeData (GeneratorLatticeCommunicator)";
     }
     currentRequestDone = false;
-    if(!firstRequestDone) {
-        // first request, must allocate initial memory block
-        emit allocateInitialLatticeDataHandler(latticeData, allocatedWidth, allocatedHeight);
-    }
     emit writeLatticeDataHandler(latticeData, allocatedWidth, allocatedHeight);
 }
 

--- a/autonomx/GeneratorLatticeCommunicator.h
+++ b/autonomx/GeneratorLatticeCommunicator.h
@@ -1,0 +1,42 @@
+// Copyright 2020, Xmodal
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <QObject>
+
+#include "Generator.h"
+
+class GeneratorLatticeCommunicator : public QObject {
+    Q_OBJECT
+public:
+    GeneratorLatticeCommunicator();
+    void updateGenerator(Generator* generator);
+    void writeLatticeData(double** latticeData, int* allocatedWidth, int* allocatedHeight);
+
+    bool isCurrentRequestDone();
+    bool isFirstRequestDone();
+private:
+    Generator* generator = nullptr;
+    bool currentRequestDone = true;
+    bool firstRequestDone = false;
+    QMetaObject::Connection connectionRequestLatticeData;
+    QMetaObject::Connection connectionRequestLatticeDataCompleted;
+signals:
+    // this shouldn't be used from the outside. this is emitted from writeLatticeData, which also sets some important state variables.
+    void requestLatticeData(double** latticeData, int* allocatedWidth, int* allocatedHeight);
+public slots:
+    void requestLatticeDataCompleted();
+};

--- a/autonomx/GeneratorLatticeCommunicator.h
+++ b/autonomx/GeneratorLatticeCommunicator.h
@@ -24,7 +24,7 @@ class GeneratorLatticeCommunicator : public QObject {
 public:
     GeneratorLatticeCommunicator();
     void updateGenerator(Generator* generator);
-    void writeLatticeData(double** latticeData, int* allocatedWidth, int* allocatedHeight);
+    void writeLatticeData(float** latticeData, int* allocatedWidth, int* allocatedHeight);
 
     bool isCurrentRequestDone();
     bool isFirstRequestDone();
@@ -32,11 +32,14 @@ private:
     Generator* generator = nullptr;
     bool currentRequestDone = true;
     bool firstRequestDone = false;
-    QMetaObject::Connection connectionRequestLatticeData;
-    QMetaObject::Connection connectionRequestLatticeDataCompleted;
+    bool flagDebug = false;
+    QMetaObject::Connection connectionAllocateInitialLatticeData;
+    QMetaObject::Connection connectionWriteLatticeData;
+    QMetaObject::Connection connectionWriteLatticeDataCompleted;
 signals:
-    // this shouldn't be used from the outside. this is emitted from writeLatticeData, which also sets some important state variables.
-    void requestLatticeData(double** latticeData, int* allocatedWidth, int* allocatedHeight);
+    // these shouldn't be used from the outside. these are emitted from writeLatticeData.
+    void allocateInitialLatticeDataHandler(float** latticeData, int* allocatedWidth, int* allocatedHeight);
+    void writeLatticeDataHandler(float** latticeData, int* allocatedWidth, int* allocatedHeight);
 public slots:
     void requestLatticeDataCompleted();
 };

--- a/autonomx/GeneratorLatticeCommunicator.h
+++ b/autonomx/GeneratorLatticeCommunicator.h
@@ -33,12 +33,10 @@ private:
     bool currentRequestDone = true;
     bool firstRequestDone = false;
     bool flagDebug = false;
-    QMetaObject::Connection connectionAllocateInitialLatticeData;
     QMetaObject::Connection connectionWriteLatticeData;
     QMetaObject::Connection connectionWriteLatticeDataCompleted;
 signals:
-    // these shouldn't be used from the outside. these are emitted from writeLatticeData.
-    void allocateInitialLatticeDataHandler(float** latticeData, int* allocatedWidth, int* allocatedHeight);
+    // this shouldn't be used from the outside. this is emitted from writeLatticeData.
     void writeLatticeDataHandler(float** latticeData, int* allocatedWidth, int* allocatedHeight);
 public slots:
     void requestLatticeDataCompleted();

--- a/autonomx/GeneratorLatticeRenderer.cpp
+++ b/autonomx/GeneratorLatticeRenderer.cpp
@@ -56,8 +56,6 @@ GeneratorLatticeRenderer::~GeneratorLatticeRenderer() {
     if(flagDebug) {
         qDebug() << "destructor (GeneratorLatticeRenderer)\tid = " << QThread::currentThreadId();
     }
-    // delete function set
-    delete functions;
     // delete shader program
     delete program;
     // delete communicator

--- a/autonomx/GeneratorLatticeRenderer.cpp
+++ b/autonomx/GeneratorLatticeRenderer.cpp
@@ -1,0 +1,173 @@
+// Copyright 2020, Xmodal
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include <QDebug>
+#include "GeneratorLatticeRenderer.h"
+#include "GeneratorLattice.h"
+#include "AppModel.h"
+
+GeneratorLatticeRenderer::GeneratorLatticeRenderer() : QQuickFramebufferObject::Renderer() {
+    if(flagDebug) {
+        qDebug() << "constructor (GeneratorLatticeRenderer)";
+    }
+    // init the shader program
+    program = new QOpenGLShaderProgram();
+    program->addCacheableShaderFromSourceFile(QOpenGLShader::Vertex, ":/shaders/lattice.vert");
+    program->addCacheableShaderFromSourceFile(QOpenGLShader::Fragment, ":/shaders/lattice.frag");
+    program->bindAttributeLocation("vertices", 0);
+    program->link();
+
+    QString log = program->log();
+    if(flagDebug && log != "") {
+        qDebug() << "constructor (GeneratorLatticeRenderer): Error in shader compilation or linking: " << log;
+    }
+}
+
+GeneratorLatticeRenderer::~GeneratorLatticeRenderer() {
+    // delete shader program
+    delete program;
+    // delete supersampling framebuffer if it exists
+    if(flagSuper) {
+        if(framebufferSuper != nullptr) {
+            delete framebufferSuper;
+        }
+    }
+}
+
+void GeneratorLatticeRenderer::render() {
+    if(flagDebug) {
+        qDebug() << "render (GeneratorLatticeRenderer)";
+    }
+
+    // exit loop if not visible
+    if(!visible) {
+        if(flagDebug) {
+            qDebug() << "render (GeneratorLatticeRenderer): not visible, exiting loop";
+        }
+        return;
+    }
+
+    if(synchronized) {
+        synchronized = false;
+        if(flagDebug) {
+            qDebug() << "render (GeneratorLatticeRenderer): synchronization detected just before render";
+        }
+        framebuffer = this->framebufferObject();
+        if(flagSuper) {
+            // check to see if the framebuffer size changed
+            QSize sizeNew = framebuffer->size();
+            if(sizeNew != size) {
+                // the size changed, we need to update the supersampling framebuffer
+                size = sizeNew;
+                if(flagDebug) {
+                    qDebug() << "render (GeneratorLatticeRenderer): synchronization caused framebuffer size change, updating supersampling framebuffer";
+                }
+                if(framebufferSuper != nullptr) {
+                    // deallocate old supersampling framebuffer if it exists
+                    delete framebufferSuper;
+                }
+                // create a new supersampling framebuffer
+                sizeSuper = size * factorSuper;
+                framebufferSuper = new QOpenGLFramebufferObject(sizeSuper);
+            }
+        }
+    }
+
+    // Play nice with the RHI. Not strictly needed when the scenegraph uses
+    // OpenGL directly.
+    window->beginExternalCommands();
+
+    if(flagSuper) {
+        // bind supersampling framebuffer
+        framebufferSuper->bind();
+
+        // set viewport size to match supersampling framebuffer
+        glViewport(0, 0, sizeSuper.width(), sizeSuper.height());
+    }
+
+    // bind shaders
+    program->bind();
+
+    // TODO: what does this do
+    program->enableAttributeArray(0);
+
+    // simple rectangle covering the whole NDC XY plane
+    float values[] = {
+        -1, -1,
+        1, -1,
+        -1, 1,
+        1, 1
+    };
+
+    // This example relies on (deprecated) client-side pointers for the vertex
+    // input. Therefore, we have to make sure no vertex buffer is bound.
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+    // TODO: what does this do
+    program->setAttributeArray(0, GL_FLOAT, values, 2);
+
+    // disable depth test
+    glDisable(GL_DEPTH_TEST);
+
+    // draw
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+    // TODO: what does this do
+    program->disableAttributeArray(0);
+
+    // unbind shaders
+    program->release();
+
+    if(flagSuper) {
+        // release supersampling framebuffer
+        framebufferSuper->release();
+
+        // blit supersampling framebuffer onto real framebuffer, performing downsampling
+        QOpenGLFramebufferObject::blitFramebuffer(framebuffer, QRect(0, 0, size.width(), size.height()), framebufferSuper, QRect(0, 0, sizeSuper.width(), sizeSuper.height()), GL_COLOR_BUFFER_BIT, GL_LINEAR);
+    }
+
+    // restore previous OpenGL state
+    window->resetOpenGLState();
+
+    // TODO: what does this do
+    window->endExternalCommands();
+
+    // render again if visible
+    if(visible) {
+        update();
+    }
+}
+
+void GeneratorLatticeRenderer::synchronize(QQuickFramebufferObject *item) {
+    // sync with GeneratorLattice
+    if(flagDebug) {
+        qDebug() << "synchronize (GeneratorLatticeRenderer)";
+    }
+    // update window
+    window = item->window();
+    // update visible
+    visible = item->isVisible();
+    if(visible) {
+        update();
+    }
+    // set synchronized flag
+    synchronized = true;
+    // update linked generator
+    // TODO: uncomment this once AppModel is properly populated
+    /*
+    generatorID = ((GeneratorLattice*) item)->getGeneratorID();
+    generator = AppModel::getInstance().getGenerator(generatorID);
+    */
+}

--- a/autonomx/GeneratorLatticeRenderer.cpp
+++ b/autonomx/GeneratorLatticeRenderer.cpp
@@ -43,6 +43,11 @@ GeneratorLatticeRenderer::~GeneratorLatticeRenderer() {
     delete program;
     // delete communicator
     delete communicator;
+    // delete lattice data if it exists
+    if(latticeData != nullptr) {
+        delete *latticeData;
+        delete latticeData;
+    }
     // delete supersampling framebuffer if it exists
     if(flagSuper) {
         if(framebufferSuper != nullptr) {

--- a/autonomx/GeneratorLatticeRenderer.cpp
+++ b/autonomx/GeneratorLatticeRenderer.cpp
@@ -111,12 +111,24 @@ void GeneratorLatticeRenderer::render() {
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
+        // clear the default framebuffer
+        framebuffer->bind();
+
+        glClearColor(0.0, 0.0, 0.0, 0.0);
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        framebuffer->release();
+
         if(flagSuper) {
             // bind supersampling framebuffer
             framebufferSuper->bind();
 
             // set viewport size to match supersampling framebuffer
             glViewport(0, 0, sizeSuper.width(), sizeSuper.height());
+
+            // clear the supersampling framebuffer
+            glClearColor(0.0, 0.0, 0.0, 0.0);
+            glClear(GL_COLOR_BUFFER_BIT);
         }
 
         // bind shaders

--- a/autonomx/GeneratorLatticeRenderer.cpp
+++ b/autonomx/GeneratorLatticeRenderer.cpp
@@ -36,6 +36,9 @@ GeneratorLatticeRenderer::GeneratorLatticeRenderer() : QQuickFramebufferObject::
 
     // init communicator
     communicator = new GeneratorLatticeCommunicator();
+
+    // init latticeData
+    *latticeData = nullptr;
 }
 
 GeneratorLatticeRenderer::~GeneratorLatticeRenderer() {
@@ -47,7 +50,7 @@ GeneratorLatticeRenderer::~GeneratorLatticeRenderer() {
     // delete communicator
     delete communicator;
     // delete lattice data (inner pointer) if it exists
-    if(*allocatedWidth != 0 && *allocatedHeight != 0) {
+    if(*latticeData != nullptr) {
         delete *latticeData;
     }
     // delete lattice data (outer pointer)

--- a/autonomx/GeneratorLatticeRenderer.cpp
+++ b/autonomx/GeneratorLatticeRenderer.cpp
@@ -109,7 +109,7 @@ void GeneratorLatticeRenderer::render() {
         glBindTexture(GL_TEXTURE_2D, texture);
         glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, *allocatedWidth, *allocatedHeight, 0, GL_RED, GL_FLOAT, *latticeData);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
         if(flagSuper) {
             // bind supersampling framebuffer

--- a/autonomx/GeneratorLatticeRenderer.cpp
+++ b/autonomx/GeneratorLatticeRenderer.cpp
@@ -168,9 +168,6 @@ void GeneratorLatticeRenderer::render() {
             QOpenGLFramebufferObject::blitFramebuffer(framebuffer, QRect(0, 0, size.width(), size.height()), framebufferSuper, QRect(0, 0, sizeSuper.width(), sizeSuper.height()), GL_COLOR_BUFFER_BIT, GL_LINEAR);
         }
 
-        glClearColor(0.0, 1.0, 0.0, 1.0);
-        glClear(GL_COLOR_BUFFER_BIT);
-
         // restore previous OpenGL state
         window->resetOpenGLState();
 
@@ -181,7 +178,9 @@ void GeneratorLatticeRenderer::render() {
 
         window->beginExternalCommands();
 
-        glClearColor(0.0, 0.0, 0.0, 1.0);
+        framebuffer->bind();
+
+        glClearColor(0.0, 0.0, 0.0, 0.0);
         glClear(GL_COLOR_BUFFER_BIT);
 
         window->resetOpenGLState();

--- a/autonomx/GeneratorLatticeRenderer.cpp
+++ b/autonomx/GeneratorLatticeRenderer.cpp
@@ -53,7 +53,7 @@ GeneratorLatticeRenderer::~GeneratorLatticeRenderer() {
 
 void GeneratorLatticeRenderer::render() {
     if(flagDebug) {
-        qDebug() << "render (GeneratorLatticeRenderer)";
+        qDebug() << "render (GeneratorLatticeRenderer)\tid = " << QThread::currentThreadId();
     }
 
     // exit loop if not visible
@@ -88,7 +88,6 @@ void GeneratorLatticeRenderer::render() {
     }
 
     // only render if lattice data is ready
-    //if(writeLatticeDataFirstDone) {
     if(communicator->isFirstRequestDone()) {
         // lock the lattice data mutex since we want to use that data
         generator->lockLatticeDataMutex();
@@ -139,12 +138,6 @@ void GeneratorLatticeRenderer::render() {
         if(communicator->isCurrentRequestDone()) {
             communicator->requestLatticeData(latticeData, allocatedWidth, allocatedHeight);
         }
-        /*
-        if(writeLatticeDataCurrentDone) {
-            writeLatticeDataCurrentDone = false;
-            emit writeLatticeData(latticeData, allocatedWidth, allocatedHeight);
-        }
-        */
 
         // TODO: what does this do
         program->disableAttributeArray(0);
@@ -195,16 +188,6 @@ void GeneratorLatticeRenderer::synchronize(QQuickFramebufferObject *item) {
 
         // request lattice data
         communicator->requestLatticeData(latticeData, allocatedWidth, allocatedHeight);
-
-        /*
-        // connect new generator
-        connectionWriteLatticeData = QObject::connect(this, &GeneratorLatticeRenderer::writeLatticeData, generator, &Generator::writeLatticeData);
-        connectionWriteLatticeDataCompleted = QObject::connect(generator, &Generator::writeLatticeDataCompleted, this, &GeneratorLatticeRenderer::writeLatticeDataCompleted);
-
-        // request the lattice data
-        writeLatticeDataCurrentDone = false;
-        emit writeLatticeData(latticeData, allocatedWidth, allocatedHeight);
-        */
     } else {
         // check to see if the linked generator changed
         int generatorIDNew = ((GeneratorLattice*) item)->getGeneratorID();
@@ -216,20 +199,6 @@ void GeneratorLatticeRenderer::synchronize(QQuickFramebufferObject *item) {
 
             // request lattice data
             communicator->requestLatticeData(latticeData, allocatedWidth, allocatedHeight);
-
-            /*
-            // disconnect old generator
-            QObject::disconnect(connectionWriteLatticeData);
-            QObject::disconnect(connectionWriteLatticeDataCompleted);
-
-            // connect new generator
-            connectionWriteLatticeData = QObject::connect(this, &GeneratorLatticeRenderer::writeLatticeData, generator, &Generator::writeLatticeData);
-            connectionWriteLatticeDataCompleted = QObject::connect(generator, &Generator::writeLatticeDataCompleted, this, &GeneratorLatticeRenderer::writeLatticeDataCompleted);
-
-            // request the lattice data
-            writeLatticeDataCurrentDone = false;
-            emit writeLatticeData(latticeData, allocatedWidth, allocatedHeight);
-            */
         }
     }
 
@@ -238,9 +207,4 @@ void GeneratorLatticeRenderer::synchronize(QQuickFramebufferObject *item) {
     if(visible) {
         update();
     }
-}
-
-void GeneratorLatticeRenderer::writeLatticeDataCompleted() {
-    writeLatticeDataCurrentDone = false;
-    writeLatticeDataFirstDone = true;
 }

--- a/autonomx/GeneratorLatticeRenderer.cpp
+++ b/autonomx/GeneratorLatticeRenderer.cpp
@@ -124,7 +124,7 @@ void GeneratorLatticeRenderer::render() {
         // bind the texture
         GLuint texture;
         functions->glActiveTexture(GL_TEXTURE0);
-        functions->glUniform1i(glGetUniformLocation(program->programId(), "texture"), 0);
+        functions->glUniform1i(functions->glGetUniformLocation(program->programId(), "texture"), 0);
         functions->glGenTextures(1, &texture);
         functions->glBindTexture(GL_TEXTURE_2D, texture);
         functions->glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, *allocatedWidth, *allocatedHeight, 0, GL_RED, GL_FLOAT, *latticeData);

--- a/autonomx/GeneratorLatticeRenderer.h
+++ b/autonomx/GeneratorLatticeRenderer.h
@@ -1,0 +1,45 @@
+// Copyright 2020, Xmodal
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <QQuickFramebufferObject>
+#include <QOpenGLFunctions>
+#include <QOpenGLShaderProgram>
+#include <QOpenGLFramebufferObject>
+#include <QQuickWindow>
+#include "Generator.h"
+
+class GeneratorLatticeRenderer : public QQuickFramebufferObject::Renderer {
+public:
+    GeneratorLatticeRenderer();
+    ~GeneratorLatticeRenderer();
+    void render();
+    void synchronize(QQuickFramebufferObject *item);
+private:
+    QOpenGLShaderProgram *program;      // pointer to shader
+    QQuickWindow *window;               // pointer to window
+    QOpenGLFramebufferObject *framebuffer = nullptr;        // pointer to the assigned framebuffer that is displayed in QML
+    QOpenGLFramebufferObject *framebufferSuper = nullptr;   // pointer to high resolution framebuffer that will be downsampled
+    QSize size;                     // size of the assigned framebuffer
+    QSize sizeSuper = QSize(0, 0);  // size of the supersampling framebuffer
+    int factorSuper = 2;            // supersampling factor
+    bool visible;                   // indicates if the object is visible in QML and turns on and off the render loop accordingly
+    bool synchronized = false;      // indicates if there was a call to synchronize since the last render call
+    bool flagSuper = true;          // enables supersampling
+    bool flagDebug = true;          // enables debug
+    int generatorID;                // associated generator id
+    Generator* generator;           // associated generator
+};

--- a/autonomx/GeneratorLatticeRenderer.h
+++ b/autonomx/GeneratorLatticeRenderer.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <QQuickFramebufferObject>
+#include <QOpenGLContext>
 #include <QOpenGLFunctions>
 #include <QOpenGLShaderProgram>
 #include <QOpenGLFramebufferObject>
@@ -30,6 +31,7 @@ public:
     void render();
     void synchronize(QQuickFramebufferObject *item);
 private:
+    QOpenGLFunctions* functions;            // pointer to OpenGL function set
     QOpenGLShaderProgram *program;          // pointer to shader
     QQuickWindow *window;                   // pointer to window
     QOpenGLFramebufferObject *framebuffer = nullptr;        // pointer to the assigned framebuffer that is displayed in QML
@@ -45,7 +47,7 @@ private:
     int generatorID;                        // associated generator id
     Generator* generator;                   // associated generator
     GeneratorLatticeCommunicator* communicator;
-    float** latticeData = new float*;       // the lattice data used to draw the graphics
-    int* allocatedWidth = new int(0);       // the width of allocated flattened array in the memory block pointed by latticeData
-    int* allocatedHeight = new int(0);      // the height of allocated flattened array in the memory block pointed by latticeData
+    float** latticeData;       // the lattice data used to draw the graphics
+    int* allocatedWidth;       // the width of allocated flattened array in the memory block pointed by latticeData
+    int* allocatedHeight;      // the height of allocated flattened array in the memory block pointed by latticeData
 };

--- a/autonomx/GeneratorLatticeRenderer.h
+++ b/autonomx/GeneratorLatticeRenderer.h
@@ -15,17 +15,15 @@
 
 #pragma once
 
-#include <QObject>
 #include <QQuickFramebufferObject>
 #include <QOpenGLFunctions>
 #include <QOpenGLShaderProgram>
 #include <QOpenGLFramebufferObject>
 #include <QQuickWindow>
 #include "Generator.h"
+#include "GeneratorLatticeCommunicator.h"
 
-// multiple inheritance is gross, but needed to allow connections to work
-class GeneratorLatticeRenderer : public QQuickFramebufferObject::Renderer, public QObject {
-    Q_OBJECT
+class GeneratorLatticeRenderer : public QQuickFramebufferObject::Renderer {
 public:
     GeneratorLatticeRenderer();
     ~GeneratorLatticeRenderer();
@@ -46,13 +44,14 @@ private:
     bool flagDebug = true;                  // enables debug
     int generatorID;                        // associated generator id
     Generator* generator;                   // associated generator
-    double* latticeData = nullptr;          // the lattice data used to draw the graphics
-    int* allocatedWidth = nullptr;          // the width of allocated flattened array in the memory block pointed by latticeData
-    int* allocatedHeight = nullptr;         // the height of allocated flattened array in the memory block pointed by latticeData
+    double** latticeData = nullptr;         // the lattice data used to draw the graphics
+    int* allocatedWidth = new int(0);       // the width of allocated flattened array in the memory block pointed by latticeData
+    int* allocatedHeight = new int(0);      // the height of allocated flattened array in the memory block pointed by latticeData
     QMetaObject::Connection connectionWriteLatticeData;         // connection from GeneratorLatticeRenderer's writeLatticeData signal to Generator's writeLatticeData slot
     QMetaObject::Connection connectionWriteLatticeDataCompleted;// connection from Generator's writeLatticeDataCompleted signal to GeneratorLatticeRenderer's writeLatticeDataCompleted slot
     bool writeLatticeDataCurrentDone = true;// indicates if the current writeLatticeData call is done
     bool writeLatticeDataFirstDone = false; // indicates if a the first writeLatticeData call is done, meaning there is valid data to use
+    GeneratorLatticeCommunicator* communicator;
 signals:
     void writeLatticeData(double* latticeData, int* allocatedWidth, int* allocatedHeight);
 public slots:

--- a/autonomx/GeneratorLatticeRenderer.h
+++ b/autonomx/GeneratorLatticeRenderer.h
@@ -41,19 +41,11 @@ private:
     bool synchronized = false;              // indicates if there was a call to synchronize since the last render call
     bool synchronizedFirstDone = false;     // indicates if the object was ever synchronized
     bool flagSuper = true;                  // enables supersampling
-    bool flagDebug = true;                  // enables debug
+    bool flagDebug = false;                 // enables debug
     int generatorID;                        // associated generator id
     Generator* generator;                   // associated generator
+    GeneratorLatticeCommunicator* communicator;
     double** latticeData = nullptr;         // the lattice data used to draw the graphics
     int* allocatedWidth = new int(0);       // the width of allocated flattened array in the memory block pointed by latticeData
     int* allocatedHeight = new int(0);      // the height of allocated flattened array in the memory block pointed by latticeData
-    QMetaObject::Connection connectionWriteLatticeData;         // connection from GeneratorLatticeRenderer's writeLatticeData signal to Generator's writeLatticeData slot
-    QMetaObject::Connection connectionWriteLatticeDataCompleted;// connection from Generator's writeLatticeDataCompleted signal to GeneratorLatticeRenderer's writeLatticeDataCompleted slot
-    bool writeLatticeDataCurrentDone = true;// indicates if the current writeLatticeData call is done
-    bool writeLatticeDataFirstDone = false; // indicates if a the first writeLatticeData call is done, meaning there is valid data to use
-    GeneratorLatticeCommunicator* communicator;
-signals:
-    void writeLatticeData(double* latticeData, int* allocatedWidth, int* allocatedHeight);
-public slots:
-    void writeLatticeDataCompleted();       // called once writeLatticeData is done, allows a new writeLatticeData signal to be emitted at the end of the next render cycle
 };

--- a/autonomx/GeneratorLatticeRenderer.h
+++ b/autonomx/GeneratorLatticeRenderer.h
@@ -45,7 +45,7 @@ private:
     int generatorID;                        // associated generator id
     Generator* generator;                   // associated generator
     GeneratorLatticeCommunicator* communicator;
-    double** latticeData = nullptr;         // the lattice data used to draw the graphics
+    float** latticeData = new float*;       // the lattice data used to draw the graphics
     int* allocatedWidth = new int(0);       // the width of allocated flattened array in the memory block pointed by latticeData
     int* allocatedHeight = new int(0);      // the height of allocated flattened array in the memory block pointed by latticeData
 };

--- a/autonomx/GeneratorModel.h
+++ b/autonomx/GeneratorModel.h
@@ -20,6 +20,7 @@
 #include <QModelIndex>
 #include <QSharedPointer>
 #include <QList>
+#include <QHash>
 #include <QMetaObject>
 #include <GeneratorFacade.h>
 
@@ -38,7 +39,7 @@ public:
         OutputMonitorHistorySizeValidRole
     };
 
-    GeneratorModel(QSharedPointer<QList<QSharedPointer<GeneratorFacade>>> generatorFacades);
+    GeneratorModel(QSharedPointer<QList<QSharedPointer<GeneratorFacade>>> generatorFacadesList, QSharedPointer<QHash<int, QSharedPointer<GeneratorFacade>>> generatorFacadesHashMap);
     ~GeneratorModel();
 
     // GeneratorModel is constructed from a GeneratorFacade list which is identical to the one found in AppModel. This is not a copy, this is the same memory location.
@@ -72,7 +73,8 @@ public slots:
 
 private:
     QList<QMetaObject::Connection> connections;
-    QSharedPointer<QList<QSharedPointer<GeneratorFacade>>> generatorFacades;
+    QSharedPointer<QList<QSharedPointer<GeneratorFacade>>> generatorFacadesList;
+    QSharedPointer<QHash<int, QSharedPointer<GeneratorFacade>>> generatorFacadesHashMap;
     bool flagDebug = false;
     const QHash<int, QByteArray> roleMap = {
         {NameRole, "name"},

--- a/autonomx/SpikingNet.cpp
+++ b/autonomx/SpikingNet.cpp
@@ -64,43 +64,43 @@ void SpikingNet::initialize() {
     }
 
     // setup vectors
-    neurons.resize(neuronSize);
+    neurons.resize(latticeWidth * latticeHeight);
 
     outputGroupSpiking.resize(outputGroupSize, 0);
     outputGroupActivation.resize(outputGroupSize, 0);
 
-    STDPTimes.resize(neuronSize, 0);
+    STDPTimes.resize(latticeWidth * latticeHeight, 0);
 
     input.resize(inputGroupSize, 0);
     output.resize(outputGroupSize, 0);
 
     // allocate memory for STP variables
-    STPu = new double[neuronSize];
-    STPx = new double[neuronSize];
-    STPw = new double[neuronSize];
+    STPu = new double[latticeWidth * latticeHeight];
+    STPx = new double[latticeWidth * latticeHeight];
+    STPw = new double[latticeWidth * latticeHeight];
 
     // initialize STP variables
-    for(int i = 0; i < neuronSize; ++i) {
+    for(int i = 0; i < latticeWidth * latticeHeight; ++i) {
         STPw[i] = 1.0;
         STPx[i] = 1.0;
         STPu[i] = 0.0;
     }
 
     // allocate memory for weights
-    weights = new double*[neuronSize];
-    for(int i = 0; i < neuronSize; ++i) {
-        weights[i] = new double[neuronSize];
+    weights = new double*[latticeWidth * latticeHeight];
+    for(int i = 0; i < latticeWidth * latticeHeight; ++i) {
+        weights[i] = new double[latticeWidth * latticeHeight];
     }
 
     // initialize weights
-    for(int i = 0; i < neuronSize; ++i) {
-        for(int j = 0; j < neuronSize; ++j) {
+    for(int i = 0; i < latticeWidth * latticeHeight; ++i) {
+        for(int j = 0; j < latticeWidth * latticeHeight; ++j) {
             weights[i][j] = 0.;
         }
     }
 
     // set neuron types
-    for(int i = 0; i < neuronSize; ++i) {
+    for(int i = 0; i < latticeWidth * latticeHeight; ++i) {
         if(i < inhibitorySize) {
             neurons[i].setNeuronType(inhibitoryNeuronType);
         } else{
@@ -143,7 +143,7 @@ void SpikingNet::reset() {
     STPw = 0;
 
     // delete weights
-    for(int i = 0; i < neuronSize; ++i) {
+    for(int i = 0; i < latticeWidth * latticeHeight; ++i) {
         delete[] weights[i];
         weights[i] = 0;
     }
@@ -179,15 +179,15 @@ int SpikingNet::indexOutputNeuron(int i) {
 
 void SpikingNet::setSparseNetwork() {
 
-    std::uniform_int_distribution<> randomNeurons(0, neuronSize - 1);
+    std::uniform_int_distribution<> randomNeurons(0, latticeWidth * latticeHeight - 1);
     std::uniform_real_distribution<> randomUniform(0.0, 1.0);
 
     int connectionSum = 0;
     int destinationArray[connectionsPerNeuron];
 
     // in case of non fully connected
-    if(connectionsPerNeuron != neuronSize) {
-        for(int source = 0; source < neuronSize; ++source) {
+    if(connectionsPerNeuron != latticeWidth * latticeHeight) {
+        for(int source = 0; source < latticeWidth * latticeHeight; ++source) {
             for(int n = 0; n < connectionsPerNeuron; n++) {
                 // initialize to something that won't be matched when we check if the candidate is already used
                 destinationArray[n] = -1;
@@ -215,7 +215,7 @@ void SpikingNet::setSparseNetwork() {
             for(int j = 0; j < connectionsPerNeuron; j++) {
                 int destination = destinationArray[j];
                 if(destination != source) {
-                    if(destination >= 0 && destination < neuronSize) {
+                    if(destination >= 0 && destination < latticeWidth * latticeHeight) {
                         if(source < inhibitorySize) {
                             weights[source][destination] = inhibitoryInitWeight * randomUniform(randomGenerator);
                         } else {
@@ -229,8 +229,8 @@ void SpikingNet::setSparseNetwork() {
 
     // in case of fully connected
     else {
-        for(int i = 0; i < neuronSize; ++i) {
-            for(int j = 0; j < neuronSize; j++) {
+        for(int i = 0; i < latticeWidth * latticeHeight; ++i) {
+            for(int j = 0; j < latticeWidth * latticeHeight; j++) {
                 if(i != j) {
                     if(i < inhibitorySize) {
                         weights[i][j] = inhibitoryInitWeight * randomUniform(randomGenerator);
@@ -259,8 +259,8 @@ void SpikingNet::setUniformNetwork() {
 
     int connectionSum = 0;
 
-    for(int i = 0; i < neuronSize; ++i) {
-        for(int j = 0; j < neuronSize; j++) {
+    for(int i = 0; i < latticeWidth * latticeHeight; ++i) {
+        for(int j = 0; j < latticeWidth * latticeHeight; j++) {
 
             if(i != j) {
                 if(i < inhibitorySize) {
@@ -282,8 +282,8 @@ void SpikingNet::setRandomNetwork() {
 
     int connectionSum = 0;
 
-    for(int i = 0; i < neuronSize; ++i) {
-        for(int j = 0; j < neuronSize; j++) {
+    for(int i = 0; i < latticeWidth * latticeHeight; ++i) {
+        for(int j = 0; j < latticeWidth * latticeHeight; j++) {
 
             if(i != j) {
                 if(i < inhibitorySize) {
@@ -304,12 +304,12 @@ void SpikingNet::setGridNetwork() {
 
     std::uniform_real_distribution<> randomUniform(0.0, 1.0);
 
-    for(int i = 0; i < neuronSize; ++i) {
-        int row = i / gridNetworkWidth;
-        int col = i % gridNetworkWidth;
-        for(int j = 0; j < neuronSize; j++) {
-            int row_target = j / gridNetworkWidth;
-            int col_target = j % gridNetworkWidth;
+    for(int i = 0; i < latticeWidth * latticeHeight; ++i) {
+        int row = i / latticeWidth;
+        int col = i % latticeWidth;
+        for(int j = 0; j < latticeWidth * latticeHeight; j++) {
+            int row_target = j / latticeWidth;
+            int col_target = j % latticeWidth;
             if(i < inhibitorySize) {
                 if(i != j && randomUniform(randomGenerator) < gridNetworkConnectionRate) {
                     weights[i][j] = inhibitoryInitWeight * randomUniform(randomGenerator); // HERE!!!
@@ -409,7 +409,7 @@ double softKneePositive(double value, double window) {
 
 void SpikingNet::applyFiring() {
     // apply firing status to neurons
-    for(int i = 0; i < neuronSize; i++) {
+    for(int i = 0; i < latticeWidth * latticeHeight; i++) {
         neurons[i].applyFiring();
     }
     // reset group output variables
@@ -459,7 +459,7 @@ void SpikingNet::updateInput() {
     std::normal_distribution<> randomUniform(0.0, 1.0);
 
     // pseudo thalamus noise-input
-    for(int i = 0; i < neuronSize; ++i) {
+    for(int i = 0; i < latticeWidth * latticeHeight; ++i) {
         if(i < inhibitorySize) {
             neurons[i].addToI(inhibitoryNoise * randomUniform(randomGenerator));
         }else{
@@ -468,9 +468,9 @@ void SpikingNet::updateInput() {
     }
 
     // input from connected neurons with STP
-    for(int i = 0; i < neuronSize; ++i) {
+    for(int i = 0; i < latticeWidth * latticeHeight; ++i) {
         if(neurons[i].isFiring()) {
-            for(int j = 0; j < neuronSize; ++j) {
+            for(int j = 0; j < latticeWidth * latticeHeight; ++j) {
                 if(i != j) {
                     if(i > inhibitorySize)
                         neurons[j].addToI((float) weights[i][j] * (float)STPw[i]);
@@ -486,7 +486,7 @@ void SpikingNet::updateInput() {
 void SpikingNet::updateNeurons(double deltaTime) {
 
     // update differential equation
-    for(int i = 0; i < neuronSize; ++i) {
+    for(int i = 0; i < latticeWidth * latticeHeight; ++i) {
         neurons[i].update(deltaTime);
         neurons[i].setI(0.0);
     }
@@ -523,7 +523,7 @@ void SpikingNet::computeSTDP(double deltaTime) {
     // each neuron has a STDPTimes[i] value that store how long ago it fired
     // the weight change is applied using the above function if the time difference between two neurons firing is smaller or equal to STDPWindow
 
-    for(int i = inhibitorySize; i < neuronSize; ++i) {
+    for(int i = inhibitorySize; i < latticeWidth * latticeHeight; ++i) {
         if(neurons[i].isFiring()) {
             // if the neuron is currently firing, set its STDPTimes to 0.
             STDPTimes[i] = 0;
@@ -536,9 +536,9 @@ void SpikingNet::computeSTDP(double deltaTime) {
 
     double deltaTimeMillis = deltaTime * 1000.0;
     double d;
-    for(int i = inhibitorySize; i < neuronSize; i++) {
+    for(int i = inhibitorySize; i < latticeWidth * latticeHeight; i++) {
         if(neurons[i].isFiring()) {
-            for(int j = inhibitorySize; j < neuronSize; j++) {
+            for(int j = inhibitorySize; j < latticeWidth * latticeHeight; j++) {
 
                 if(STDPTimes[j] <= STDPWindow && STDPTimes[j] != 0 && i != j) {
                     // another (uniquely different) neuron has fired in the last STDPTau frames (excluding the current frame)
@@ -566,7 +566,7 @@ void SpikingNet::computeSTDP(double deltaTime) {
 }
 
 void SpikingNet::computeSTP(double deltaTime) {
-    for(int i = inhibitorySize; i < neuronSize; ++i) {
+    for(int i = inhibitorySize; i < latticeWidth * latticeHeight; ++i) {
         STPw[i] = STPStrength * getSTPValue(i, neurons[i].isFiring(), deltaTime);
     }
 }
@@ -611,8 +611,8 @@ double SpikingNet::getSTPValue(int index, bool isFiring, double deltaTime) {
 void SpikingNet::decay(double deltaTime) {
     double decayConstantTimeCompensated = pow(decayConstant, deltaTime);
 
-    for(int i = inhibitorySize; i < neuronSize; i++) {
-        for(int j = inhibitorySize; j < neuronSize; j++) {
+    for(int i = inhibitorySize; i < latticeWidth * latticeHeight; i++) {
+        for(int j = inhibitorySize; j < latticeWidth * latticeHeight; j++) {
             weights[i][j] = weights[i][j] * decayConstantTimeCompensated;
         }
     }
@@ -667,23 +667,19 @@ void SpikingNet::wholeStimulation(double strength) {
 
 void SpikingNet::wholeNetworkStimulation() {
     //    external input
-    for(int i = 0; i < neuronSize; ++i) {
+    for(int i = 0; i < latticeWidth * latticeHeight; ++i) {
         neurons[i].addToI(stimStrength);
     }
 }
 
 void SpikingNet::wholeNetworkStimulation(double strength) {
     //    external input
-    for(int i = 0; i < neuronSize; ++i) {
+    for(int i = 0; i < latticeWidth * latticeHeight; ++i) {
             neurons[i].addToI(strength);
     }
 }
 
 // ############################### Qt read / write ###############################
-
-int SpikingNet::getNeuronSize() const {
-    return neuronSize;
-}
 
 double SpikingNet::getTimeScale() const {
     return this->timeScale;
@@ -741,31 +737,6 @@ bool SpikingNet::getFlagDecay() const {
     return this->flagDecay;
 }
 
-void SpikingNet::writeNeuronSize(int neuronSize) {
-    if(this->neuronSize == neuronSize)
-        return;
-
-    if(flagDebug) {
-        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                    std::chrono::system_clock::now().time_since_epoch()
-        );
-
-        qDebug() << "writeNeuronSize:\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
-    }
-
-    qDebug() << "WARNING: writeNeuronSize is currently disabled";
-
-    // reset network, since these parameters only take effect when the network is created anew
-    reset();
-    // do the change
-    this->neuronSize = neuronSize;
-    // re-initialize
-    initialize();
-    // signal
-    emit valueChanged("neuronSize", QVariant(neuronSize));
-    emit neuronSizeChanged(neuronSize);
-}
-
 void SpikingNet::writeTimeScale(double timeScale) {
     if(this->timeScale == timeScale)
         return;
@@ -820,7 +791,7 @@ void SpikingNet::writeInputPortion(double inputPortion) {
     }
 
     // update input size
-    inputSize = (neuronSize - inhibitorySize) * inputPortion;
+    inputSize = (latticeWidth * latticeHeight - inhibitorySize) * inputPortion;
 
     this->inputPortion = inputPortion;
     emit valueChanged("inputPortion", QVariant(inputPortion));
@@ -840,7 +811,7 @@ void SpikingNet::writeOutputPortion(double outputPortion) {
     }
 
     // update output size
-    outputSize = (neuronSize - inhibitorySize) * outputPortion;
+    outputSize = (latticeWidth * latticeHeight - inhibitorySize) * outputPortion;
 
     this->outputPortion = outputPortion;
     emit valueChanged("outputPortion", QVariant(outputPortion));
@@ -1032,16 +1003,46 @@ void SpikingNet::writeFlagDecay(bool flagDecay) {
 }
 
 void SpikingNet::writeLatticeWidthDelegate(int latticeWidth) {
-    qDebug() << "WARNING: writeLatticeWidthDelegate is unimplemented";
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "writeLatticeWidthDelegate:\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
+    }
+
+    // reset network, since memory has to be reallocated
+    reset();
+    // do the change
+    this->latticeWidth = latticeWidth;
+    // re-initialize
+    initialize();
+
+    // signals are emitted from Generator::writeLatticeWidth once this is done
 }
 
 void SpikingNet::writeLatticeHeightDelegate(int latticeHeight) {
-    qDebug() << "WARNING: writeLatticeHeightDelegate is unimplemented";
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "writeLatticeHeightDelegate:\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
+    }
+
+    // reset network, since memory has to be reallocated
+    reset();
+    // do the change
+    this->latticeHeight = latticeHeight;
+    // re-initialize
+    initialize();
+
+    // signals are emitted from Generator::writeLatticeWidth once this is done
 }
 
 void SpikingNet::writeLatticeDataDelegate(float *latticeData) {
-    int width = getLatticeWidth();
-    int height = getLatticeHeight();
+    int width = latticeWidth;
+    int height = latticeHeight;
     for(int x = 0; x < width; x++) {
         for(int y = 0; y < height; y++) {
             int index = x % width + y * width;

--- a/autonomx/SpikingNet.cpp
+++ b/autonomx/SpikingNet.cpp
@@ -21,7 +21,7 @@
 
 // ############################### initialization routines ###############################
 
-SpikingNet::SpikingNet(int id) : Generator(id) {
+SpikingNet::SpikingNet(int id) : Generator(id, "Spiking Neural Network", "SNN", "An interconnected network of biologically-modeled neurons.") {
     if(flagDebug) {
         std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
                     std::chrono::system_clock::now().time_since_epoch()
@@ -29,12 +29,6 @@ SpikingNet::SpikingNet(int id) : Generator(id) {
 
         qDebug() << "constructor (SpikingNet):\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
     }
-
-    // default values for descriptive properties
-    name = "Spiking Neural Network";
-    type = "SNN";
-    description = "An interconnected network of biologically-modeled neurons.";
-    outputMonitor = 0;
 
     initialize();
 }
@@ -759,6 +753,8 @@ void SpikingNet::writeNeuronSize(int neuronSize) {
         qDebug() << "writeNeuronSize:\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
     }
 
+    qDebug() << "WARNING: writeNeuronSize is currently disabled";
+
     // reset network, since these parameters only take effect when the network is created anew
     reset();
     // do the change
@@ -1033,4 +1029,23 @@ void SpikingNet::writeFlagDecay(bool flagDecay) {
     this->flagDecay = flagDecay;
     emit valueChanged("flagDecay", QVariant(flagDecay));
     emit flagDecayChanged(flagDecay);
+}
+
+void SpikingNet::writeLatticeWidthDelegate(int latticeWidth) {
+    qDebug() << "WARNING: writeLatticeWidthDelegate is unimplemented";
+}
+
+void SpikingNet::writeLatticeHeightDelegate(int latticeHeight) {
+    qDebug() << "WARNING: writeLatticeHeightDelegate is unimplemented";
+}
+
+void SpikingNet::writeLatticeDataDelegate(double *latticeData) {
+    int width = getLatticeWidth();
+    int height = getLatticeHeight();
+    for(int x = 0; x < width; x++) {
+        for(int y = 0; y < height; y++) {
+            int index = x % width + y * width;
+            latticeData[index] = (neurons[index].getV() - neurons[index].getC()) / (neurons[index].getPotentialThreshold() - neurons[index].getC());
+        }
+    }
 }

--- a/autonomx/SpikingNet.cpp
+++ b/autonomx/SpikingNet.cpp
@@ -1039,13 +1039,13 @@ void SpikingNet::writeLatticeHeightDelegate(int latticeHeight) {
     qDebug() << "WARNING: writeLatticeHeightDelegate is unimplemented";
 }
 
-void SpikingNet::writeLatticeDataDelegate(double *latticeData) {
+void SpikingNet::writeLatticeDataDelegate(float *latticeData) {
     int width = getLatticeWidth();
     int height = getLatticeHeight();
     for(int x = 0; x < width; x++) {
         for(int y = 0; y < height; y++) {
             int index = x % width + y * width;
-            latticeData[index] = (neurons[index].getV() - neurons[index].getC()) / (neurons[index].getPotentialThreshold() - neurons[index].getC());
+            latticeData[index] = (float) (neurons[index].getV() - neurons[index].getC()) / (neurons[index].getPotentialThreshold() - neurons[index].getC());
         }
     }
 }

--- a/autonomx/SpikingNet.h
+++ b/autonomx/SpikingNet.h
@@ -24,7 +24,6 @@
 class SpikingNet : public Generator {
     // TODO: figure out how we decide to add / remove inputs. this should probably be a property that belongs to the Generator abstract class, rather than this.
     Q_OBJECT
-    Q_PROPERTY(int neuronSize READ getNeuronSize WRITE writeNeuronSize NOTIFY neuronSizeChanged)
     Q_PROPERTY(double timeScale READ getTimeScale WRITE writeTimeScale NOTIFY timeScaleChanged)
     Q_PROPERTY(double inhibitoryPortion READ getInhibitoryPortion WRITE writeInhibitoryPortion NOTIFY inhibitoryPortionChanged)
     Q_PROPERTY(double inputPortion READ getInputPortion WRITE writeInputPortion NOTIFY inputPortionChanged)
@@ -55,14 +54,12 @@ public:
 
 private:
     NetworkType networkType = NetworkType::GridNetwork;
-    int         neuronSize = 400;
     int         connectionsPerNeuron = 20; // this is used in any non-grid network
     int         randomSeed = 0;
-    int         gridNetworkWidth = 20;
     double      gridNetworkConnectionRate = 0.01; // this is used in the grid network
 
     double      inhibitoryPortion = 0.2;
-    int         inhibitorySize = neuronSize * inhibitoryPortion;
+    int         inhibitorySize = latticeWidth * latticeHeight * inhibitoryPortion;
     NeuronType::Enum  inhibitoryNeuronType = NeuronType::ChatteringNeuron;
     double      inhibitoryInitWeight = -5.0;
     double      inhibitoryNoise = 3.0;
@@ -72,11 +69,11 @@ private:
     double      excitatoryNoise = 5.0;
 
     double      inputPortion = 0.2;
-    int         inputSize = (neuronSize - inhibitorySize) * inputPortion;
+    int         inputSize = (latticeWidth * latticeHeight - inhibitorySize) * inputPortion;
     int         inputGroupSize = 1;
 
     double      outputPortion = 0.2;
-    int         outputSize = (neuronSize - inhibitorySize) * outputPortion;
+    int         outputSize = (latticeWidth * latticeHeight - inhibitorySize) * outputPortion;
     int         outputGroupSize = 1;
 
     double      weightMax = 20.0;

--- a/autonomx/SpikingNet.h
+++ b/autonomx/SpikingNet.h
@@ -155,7 +155,7 @@ public:
     SpikingNet(int id);
     ~SpikingNet();
 
-    void computeOutput(double deltaTime);
+    void computeOutput(double deltaTime) override;
 
     int getNeuronSize() const;
     double getTimeScale() const;
@@ -173,7 +173,6 @@ public:
     bool getFlagSTDP() const;
     bool getFlagDecay() const;
 
-public slots:
     void writeNeuronSize(int neuronSize);
     void writeTimeScale(double timeScale);
     void writeInhibitoryPortion(double inhibitoryPortion);
@@ -189,6 +188,10 @@ public slots:
     void writeFlagSTP(bool flagSTP);
     void writeFlagSTDP(bool flagSTDP);
     void writeFlagDecay(bool flagDecay);
+
+    void writeLatticeWidthDelegate(int latticeWidth) override;
+    void writeLatticeHeightDelegate(int latticeHeight) override;
+    void writeLatticeDataDelegate(double* latticeData) override;
 
 signals:
     void neuronSizeChanged(int neuronSize);

--- a/autonomx/SpikingNet.h
+++ b/autonomx/SpikingNet.h
@@ -191,7 +191,7 @@ public:
 
     void writeLatticeWidthDelegate(int latticeWidth) override;
     void writeLatticeHeightDelegate(int latticeHeight) override;
-    void writeLatticeDataDelegate(double* latticeData) override;
+    void writeLatticeDataDelegate(float* latticeData) override;
 
 signals:
     void neuronSizeChanged(int neuronSize);

--- a/autonomx/autonomx.pro
+++ b/autonomx/autonomx.pro
@@ -37,6 +37,7 @@ SOURCES += \
     Generator.cpp \
     GeneratorFacade.cpp \
     GeneratorLattice.cpp \
+    GeneratorLatticeCommunicator.cpp \
     GeneratorLatticeRenderer.cpp \
     GeneratorModel.cpp \
     Izhikevich.cpp \
@@ -74,6 +75,7 @@ HEADERS += \
     Generator.h \
     GeneratorFacade.h \
     GeneratorLattice.h \
+    GeneratorLatticeCommunicator.h \
     GeneratorLatticeRenderer.h \
     GeneratorModel.h \
     Izhikevich.h \

--- a/autonomx/autonomx.pro
+++ b/autonomx/autonomx.pro
@@ -1,6 +1,7 @@
 QT += quick
 QT += core
 QT += qml
+QT += gui
 # QT += serialport
 CONFIG += c++11
 

--- a/autonomx/autonomx.pro
+++ b/autonomx/autonomx.pro
@@ -36,6 +36,8 @@ SOURCES += \
     Facade.cpp \
     Generator.cpp \
     GeneratorFacade.cpp \
+    GeneratorLattice.cpp \
+    GeneratorLatticeRenderer.cpp \
     GeneratorModel.cpp \
     Izhikevich.cpp \
     OscEngine.cpp \
@@ -71,6 +73,8 @@ HEADERS += \
     Facade.h \
     Generator.h \
     GeneratorFacade.h \
+    GeneratorLattice.h \
+    GeneratorLatticeRenderer.h \
     GeneratorModel.h \
     Izhikevich.h \
     NeuronType.h \

--- a/autonomx/components/racks/ParamsRack.qml
+++ b/autonomx/components/racks/ParamsRack.qml
@@ -27,11 +27,19 @@ Rack {
                 spacing: Stylesheet.field.spacing
 
                 NumberField {
-                    labelText: "Neurons"
+                    labelText: "Width"
                     unsigned: true
 
-                    defaultNum: generatorModel.at(genID).neuronSize
-                    onValueChanged: generatorModel.at(genID).neuronSize = newValue
+                    defaultNum: generatorModel.at(genID).latticeWidth
+                    onValueChanged: generatorModel.at(genID).latticeWidth = newValue
+                }
+
+                NumberField {
+                    labelText: "Height"
+                    unsigned: true
+
+                    defaultNum: generatorModel.at(genID).latticeHeight
+                    onValueChanged: generatorModel.at(genID).latticeHeight = newValue
                 }
 
                 SliderField {

--- a/autonomx/main.cpp
+++ b/autonomx/main.cpp
@@ -27,6 +27,7 @@
 #include "Generator.h"
 #include "GeneratorFacade.h"
 #include "GeneratorModel.h"
+#include "GeneratorLattice.h"
 #include "SpikingNet.h"
 #include "AppModel.h"
 
@@ -62,6 +63,7 @@ int main(int argc, char *argv[]) {
     qmlRegisterUncreatableType<GeneratorFacade>("ca.hexagram.xmodal.autonomx", 1, 0, "GeneratorFacade", "Cannot instanciate GeneratorFacade.");
     qmlRegisterUncreatableType<SpikingNet>("ca.hexagram.xmodal.autonomx", 1, 0, "SpikingNet", "Cannot instanciate SpikingNet.");
     qmlRegisterUncreatableType<NeuronType>("ca.hexagram.xmodal.autonomx", 1, 0, "NeuronType", "Cannot instanciate NeuronType.");
+    qmlRegisterType<GeneratorLattice>("ca.hexagram.xmodal.autonomx", 1, 0, "GeneratorLattice");
 
     AppModel::getInstance().createGenerator();
     AppModel::getInstance().start();

--- a/autonomx/main.cpp
+++ b/autonomx/main.cpp
@@ -36,13 +36,6 @@
 #include "AppNap.h"
 #endif
 
-// only include OpenGL header if platform is Windows
-#ifdef Q_OS_WIN
-#include "gl/GLU.h"
-#else
-#include <glu.h>
-#endif
-
 bool flagDebug = false;
 
 int main(int argc, char *argv[]) {

--- a/autonomx/main.cpp
+++ b/autonomx/main.cpp
@@ -36,6 +36,13 @@
 #include "AppNap.h"
 #endif
 
+// only include OpenGL header if platform is Windows
+#ifdef Q_OS_WIN
+#include "gl/GLU.h"
+#else
+#include <glu.h>
+#endif
+
 bool flagDebug = false;
 
 int main(int argc, char *argv[]) {

--- a/autonomx/pages/LatticeView.qml
+++ b/autonomx/pages/LatticeView.qml
@@ -25,7 +25,7 @@ ColumnLayout {
         // background
         Rectangle {
             anchors.fill: parent
-            color: genID < 0 ? Stylesheet.colors.white : Stylesheet.colors.generators[genID % Stylesheet.colors.generators.length]
+            color: genID < 0 ? Stylesheet.colors.white : Stylesheet.colors.outputs[genID % Stylesheet.colors.outputs.length]
         }
 
         // back arrow
@@ -101,6 +101,12 @@ ColumnLayout {
             Layout.fillWidth: true
             Layout.fillHeight: true
 
+            GeneratorLattice {
+                generatorID: 0
+                anchors.fill: parent
+            }
+
+            /*
             Rectangle {
                 anchors.fill: parent
                 color: Stylesheet.colors.black
@@ -141,11 +147,11 @@ ColumnLayout {
                 property real realHeight: mainContent.realHeight
 
                 // I/O
-                property color inputColor: Stylesheet.colors.input
+                property color inputColor: Stylesheet.colors.inputColor
                 property variant inputs: [
                     Qt.rect(2, 2, 4, 5)
                 ]
-                property color outputColor: Stylesheet.colors.output
+                property color outputColor: Stylesheet.colors.outputColor
                 property variant outputs: [
                     Qt.rect(10, 10, 2, 2)
                 ]
@@ -213,6 +219,7 @@ ColumnLayout {
                 }
                 opacity: 0.4
             }
+            */
         }
 
         // control zone

--- a/autonomx/qml.qrc
+++ b/autonomx/qml.qrc
@@ -35,5 +35,7 @@
         <file>shaders/neuron_matrix.frag</file>
         <file>stylesheet/qmldir</file>
         <file>stylesheet/Stylesheet.qml</file>
+        <file>shaders/lattice.frag</file>
+        <file>shaders/lattice.vert</file>
     </qresource>
 </RCC>

--- a/autonomx/shaders/lattice.frag
+++ b/autonomx/shaders/lattice.frag
@@ -3,6 +3,6 @@ varying highp vec2 coords;
 uniform sampler2D texture;
 
 void main() {
-    float intensity = texture2D(texture, coords * 0.25 + vec2(0.5, 0.5)).r;
+    float intensity = texture2D(texture, coords * 0.5 + vec2(0.5, 0.5)).r;
     gl_FragColor = vec4(vec3(intensity), 1.0);
 }

--- a/autonomx/shaders/lattice.frag
+++ b/autonomx/shaders/lattice.frag
@@ -1,0 +1,6 @@
+varying highp vec2 coords;
+
+void main() {
+    float inside = coords.x + coords.y < 0.0 ? 1.0 : 0.0;
+    gl_FragColor = vec4(coords.x, coords.y, inside, 1.0);
+}

--- a/autonomx/shaders/lattice.frag
+++ b/autonomx/shaders/lattice.frag
@@ -1,6 +1,8 @@
 varying highp vec2 coords;
 
+uniform sampler2D texture;
+
 void main() {
-    float inside = coords.x + coords.y < 0.0 ? 1.0 : 0.0;
-    gl_FragColor = vec4(coords.x, coords.y, inside, 1.0);
+    float intensity = texture2D(texture, coords * 0.25 + vec2(0.5, 0.5)).r;
+    gl_FragColor = vec4(vec3(intensity), 1.0);
 }

--- a/autonomx/shaders/lattice.vert
+++ b/autonomx/shaders/lattice.vert
@@ -1,0 +1,7 @@
+attribute highp vec4 vertices;
+varying highp vec2 coords;
+
+void main() {
+    gl_Position = vertices;
+    coords = vertices.xy;
+}

--- a/qosc/OscReceiver.cpp
+++ b/qosc/OscReceiver.cpp
@@ -22,6 +22,20 @@ OscReceiver::OscReceiver(quint16 port, QObject* parent) :
     connect(m_udpSocket, &QUdpSocket::readyRead, this, &OscReceiver::readyReadCb);
 }
 
+OscReceiver::~OscReceiver()
+{
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "destructor (OscReceiver):\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
+    }
+
+    m_udpSocket->close();
+    delete m_udpSocket;
+}
+
 void OscReceiver::setPort(quint16 port)
 {
     m_port = port;

--- a/qosc/OscReceiver.h
+++ b/qosc/OscReceiver.h
@@ -25,6 +25,7 @@ public:
      * @param receivePort Port number to listen to.
      */
     explicit OscReceiver(quint16 port, QObject *parent = nullptr);
+    ~OscReceiver();
     void setPort(quint16 port);
 
 signals:

--- a/qosc/OscSender.cpp
+++ b/qosc/OscSender.cpp
@@ -11,7 +11,7 @@
 OscSender::OscSender(const QString& hostAddress, quint16 port, QObject *parent) :
         QObject(parent),
         m_udpSocket(new QUdpSocket(this)),
-        m_hostAddress(hostAddress),
+        m_hostAddress(QHostAddress(hostAddress)),
         m_port(port)
 {
     if(flagDebug) {
@@ -22,7 +22,7 @@ OscSender::OscSender(const QString& hostAddress, quint16 port, QObject *parent) 
         qDebug() << "constructor (OscSender):\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
     }
 
-    m_udpSocket->connectToHost(QHostAddress(m_hostAddress) , m_port);
+    m_udpSocket->connectToHost(m_hostAddress , m_port);
 }
 
 OscSender::~OscSender()
@@ -43,14 +43,14 @@ void OscSender::setPort(quint16 port)
 {
     m_port = port;
     m_udpSocket->disconnectFromHost();
-    m_udpSocket->connectToHost(QHostAddress(m_hostAddress) , m_port);
+    m_udpSocket->connectToHost(m_hostAddress , m_port);
 }
 
 void OscSender::setHostAddress(const QString& hostAddress)
 {
-    m_hostAddress = hostAddress;
+    m_hostAddress = QHostAddress(hostAddress);
     m_udpSocket->disconnectFromHost();
-    m_udpSocket->connectToHost(QHostAddress(m_hostAddress) , m_port);
+    m_udpSocket->connectToHost(m_hostAddress , m_port);
 }
 
 void OscSender::send(const QString& oscAddress, const QVariantList& arguments) {

--- a/qosc/OscSender.cpp
+++ b/qosc/OscSender.cpp
@@ -25,6 +25,20 @@ OscSender::OscSender(const QString& hostAddress, quint16 port, QObject *parent) 
     m_udpSocket->connectToHost(QHostAddress(m_hostAddress) , m_port);
 }
 
+OscSender::~OscSender()
+{
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "destructor (OscSender):\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
+    }
+
+    m_udpSocket->close();
+    delete m_udpSocket;
+}
+
 void OscSender::setPort(quint16 port)
 {
     m_port = port;

--- a/qosc/OscSender.h
+++ b/qosc/OscSender.h
@@ -30,6 +30,7 @@ public:
      * @param parent
      */
     explicit OscSender(const QString& hostAddress, quint16 port, QObject* parent = nullptr);
+    ~OscSender();
     void setPort(quint16 port);
     void setHostAddress(const QString& hostAddress);
 


### PR DESCRIPTION
This closes #75, and closes #151.

Real-time generator lattice rendering is now implemented using OpenGL as the `GeneratorLattice` custom QML element. This is declared in the `GeneratorLattice` class, is rendered by `GeneratorLatticeRenderer`, and uses `GeneratorLatticeCommunicator` to get the data from the `Generator`. This is designed for optimal memory use and manages threading issues gracefully, eliminating race conditions with mutex protection, while also avoiding locking the `ComputeEngine` when a data update is requested by `GeneratorLatticeCommunicator` while `GeneratorLatticeRenderer` is using (and has locked the mutex to) the data. The data is only updated at the framerate of the GUI, independently of `ComputeEngine`'s update rate. Memory reallocation is taken care of properly when the lattice size changes. Invalid generator indices are also handled without a crash, and simply disable rendering. 

The shader currently used for this is very basic: this is temporary. Once this is rebased onto `dev`, @lucidism's `feature/lattice-controls` branch will be rebased on top of this, and I will work on updating `GeneratorLatticeRenderer` to accommodate the full shader created by @lucidism.

Any class deriving `Generator` must now implement the `writeLatticeDataDelegate` method. This method is called from the `writeLatticeData` slot whenever `GeneratorLatticeCommunicator` requests an update on its lattice data. `writeLatticeData` takes care of managing memory allocation initially for the lattice data, memory reallocation when the size of the lattice changes, and also takes care of managing mutex-related business for thread safety. `writeLatticeDataDelegate` takes care of writing the actual lattice data — this method is different for every algorithm derived from `Generator`.

This also unformizes lattice size settings in the backend (and implements a very rudimentary temporary frontend). All generators now support a `latticeWidth` and `latticeHeight` property that can be modified and read through QML. 

Any class deriving `Generator` must now implement the `writeLatticeWidthDelegate` and `writeLatticeHeightDelegate` methods. These methods are called by the setter methods for those QProperties (`writeLatticeWidth` and `writeLatticeHeight`). Their role is to change the value of `latticeWidth` or `latticeHeight` to the passed value while also performing any necessary changes for the algorithm to work using the new lattice size. Again, this will be unique to every algorithm deriving `Generator`.

This pull request also includes fixes to minor memory leaks, and a refactor of the connections between `OscEngine` and `Generator` for cleaner code and simplicity.