### PR TITLE
Disable OSC input / output enable / disable checkboxes

### DIFF
--- a/autonomx/components/racks/OscSettingsRack.qml
+++ b/autonomx/components/racks/OscSettingsRack.qml
@@ -13,7 +13,7 @@ ColumnLayout {
     SubRack {
         subRackTitle: "In"
         columnCount: 4
-        flagActive: true
+        flagActive: false
         flagColor: Stylesheet.colors.inputs[0]
 
         fields: [
@@ -32,7 +32,7 @@ ColumnLayout {
     SubRack {
         subRackTitle: "Out"
         columnCount: 4
-        flagActive: true
+        flagActive: false
         flagColor: Stylesheet.colors.outputs[0]
 
         fields: [


### PR DESCRIPTION
At the moment, the backend-side code that allows disabling OSC inputs and outputs doesn't exist, meaning toggling them on and off in the frontend has no effect. This could be a source of confusion for the beta testing users, so this temporarily disables them.