### PR TITLE
Fix memory leaks, fix visual glitches with history graph and minor UI tweaks

### DIFF
--- a/autonomx/AppModel.cpp
+++ b/autonomx/AppModel.cpp
@@ -102,20 +102,20 @@ AppModel::AppModel() {
     computeEngine->start();
 }
 
-QThread* AppModel::getComputeThread() const {
-    return computeThread.data();
+QSharedPointer<QThread> AppModel::getComputeThread() const {
+    return computeThread;
 }
 
-QThread* AppModel::getOscThread() const {
-    return oscThread.data();
+QSharedPointer<QThread> AppModel::getOscThread() const {
+    return oscThread;
 }
 
-ComputeEngine*  AppModel::getComputeEngine() const {
-    return computeEngine.data();
+QSharedPointer<ComputeEngine>  AppModel::getComputeEngine() const {
+    return computeEngine;
 }
 
-OscEngine* AppModel::getOscEngine() const {
-    return oscEngine.data();
+QSharedPointer<OscEngine> AppModel::getOscEngine() const {
+    return oscEngine;
 }
 
 void AppModel::createGenerator() {
@@ -278,10 +278,10 @@ QSharedPointer<Generator> AppModel::getGenerator(int id) const {
     return generatorsHashMap->value(id);
 }
 
-GeneratorFacade* AppModel::getGeneratorFacade(int id) const {
-    return generatorFacadesHashMap->value(id).data();
+QSharedPointer<GeneratorFacade> AppModel::getGeneratorFacade(int id) const {
+    return generatorFacadesHashMap->value(id);
 }
 
-GeneratorModel* AppModel::getGeneratorModel() const {
-    return generatorModel.data();
+QSharedPointer<GeneratorModel> AppModel::getGeneratorModel() const {
+    return generatorModel;
 }

--- a/autonomx/AppModel.cpp
+++ b/autonomx/AppModel.cpp
@@ -274,8 +274,8 @@ bool AppModel::validateNewGeneratorName(QString name) {
     return valid;
 }
 
-Generator* AppModel::getGenerator(int id) const {
-    return generatorsHashMap->value(id).data();
+QSharedPointer<Generator> AppModel::getGenerator(int id) const {
+    return generatorsHashMap->value(id);
 }
 
 GeneratorFacade* AppModel::getGeneratorFacade(int id) const {

--- a/autonomx/AppModel.h
+++ b/autonomx/AppModel.h
@@ -34,13 +34,15 @@ public:
         static AppModel instance;
         return instance;
     }
-    QThread*            getComputeThread() const;           // needed to exit the thread at app quit. we can only connect this from the main.
-    QThread*            getOscThread() const;               // needed to exit the thread at app quit. we can only connect this from the main.
-    ComputeEngine*      getComputeEngine() const;           // needed for connections
-    OscEngine*          getOscEngine() const;               // needed for connections
-    QSharedPointer<Generator>          getGenerator(int id) const;
-    GeneratorFacade*    getGeneratorFacade(int id) const;
-    GeneratorModel*     getGeneratorModel() const;
+    // these return shared pointers to avoid threading issues related to the deletion of these objects.
+    // be careful! whenever a Generator or GeneratorFacade is accessed through one of these, the reference must go out of scope when the generator is removed so that the objects are actually deleted.
+    QSharedPointer<QThread>         getComputeThread() const;
+    QSharedPointer<QThread>         getOscThread() const;
+    QSharedPointer<ComputeEngine>   getComputeEngine() const;
+    QSharedPointer<OscEngine>       getOscEngine() const;
+    QSharedPointer<Generator>       getGenerator(int id) const;
+    QSharedPointer<GeneratorFacade> getGeneratorFacade(int id) const;
+    QSharedPointer<GeneratorModel>  getGeneratorModel() const;
 
     Q_INVOKABLE void    createGenerator();
     Q_INVOKABLE void    deleteGenerator(int id);

--- a/autonomx/AppModel.h
+++ b/autonomx/AppModel.h
@@ -38,7 +38,7 @@ public:
     QThread*            getOscThread() const;               // needed to exit the thread at app quit. we can only connect this from the main.
     ComputeEngine*      getComputeEngine() const;           // needed for connections
     OscEngine*          getOscEngine() const;               // needed for connections
-    Generator*          getGenerator(int id) const;
+    QSharedPointer<Generator>          getGenerator(int id) const;
     GeneratorFacade*    getGeneratorFacade(int id) const;
     GeneratorModel*     getGeneratorModel() const;
 

--- a/autonomx/Generator.cpp
+++ b/autonomx/Generator.cpp
@@ -47,9 +47,6 @@ Generator::~Generator() {
 
         qDebug() << "destructor (Generator)\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id;
     }
-
-    // wait until other threads release their lock before finishing destruction
-    QMutexLocker locker(&latticeDataMutex);
 }
 
 QString Generator::getName() {

--- a/autonomx/Generator.cpp
+++ b/autonomx/Generator.cpp
@@ -47,6 +47,9 @@ Generator::~Generator() {
 
         qDebug() << "destructor (Generator)\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id;
     }
+
+    // wait until other threads release their lock before finishing destruction
+    QMutexLocker locker(&latticeDataMutex);
 }
 
 QString Generator::getName() {

--- a/autonomx/GeneratorLattice.cpp
+++ b/autonomx/GeneratorLattice.cpp
@@ -18,9 +18,19 @@
 #include "GeneratorLattice.h"
 
 QQuickFramebufferObject::Renderer * GeneratorLattice::createRenderer() const {
+    if(flagDebug) {
+        qDebug() << "constructor (GeneratorLattice)";
+    }
+
     connect(this, &GeneratorLattice::visibleChanged, this, &QQuickFramebufferObject::update);
     QQuickFramebufferObject::Renderer * renderer = new GeneratorLatticeRenderer();
     return renderer;
+}
+
+GeneratorLattice::~GeneratorLattice() {
+    if(flagDebug) {
+        qDebug() << "destructor (GeneratorLattice)";
+    }
 }
 
 int GeneratorLattice::getGeneratorID() {

--- a/autonomx/GeneratorLattice.h
+++ b/autonomx/GeneratorLattice.h
@@ -26,6 +26,8 @@ class GeneratorLattice : public QQuickFramebufferObject {
     Q_PROPERTY(QVector4D mask READ getMask WRITE writeMask NOTIFY maskChanged)
     Q_PROPERTY(float maskAlpha READ getMaskAlpha WRITE writeMaskAlpha NOTIFY maskAlphaChanged)
 public:
+    ~GeneratorLattice();
+
     QQuickFramebufferObject::Renderer * createRenderer() const;
     int getGeneratorID();
     float getSquareInPixels();

--- a/autonomx/GeneratorLatticeCommunicator.cpp
+++ b/autonomx/GeneratorLatticeCommunicator.cpp
@@ -19,7 +19,7 @@
 
 GeneratorLatticeCommunicator::GeneratorLatticeCommunicator() {}
 
-void GeneratorLatticeCommunicator::updateGenerator(Generator *generator) {
+void GeneratorLatticeCommunicator::updateGenerator(QSharedPointer<Generator> generator) {
     if(flagDebug) {
         qDebug() << "updateGenerator (GeneratorLatticeCommunicator)";
     }
@@ -32,8 +32,8 @@ void GeneratorLatticeCommunicator::updateGenerator(Generator *generator) {
     }
     this->generator = generator;
 
-    connectionWriteLatticeData = connect(this, &GeneratorLatticeCommunicator::writeLatticeDataHandler, generator, &Generator::writeLatticeData);
-    connectionWriteLatticeDataCompleted = connect(generator, &Generator::writeLatticeDataCompleted, this, &GeneratorLatticeCommunicator::requestLatticeDataCompleted);
+    connectionWriteLatticeData = connect(this, &GeneratorLatticeCommunicator::writeLatticeDataHandler, generator.data(), &Generator::writeLatticeData);
+    connectionWriteLatticeDataCompleted = connect(generator.data(), &Generator::writeLatticeDataCompleted, this, &GeneratorLatticeCommunicator::requestLatticeDataCompleted);
 }
 
 void GeneratorLatticeCommunicator::writeLatticeData(float** latticeData, int* allocatedWidth, int* allocatedHeight) {

--- a/autonomx/GeneratorLatticeCommunicator.h
+++ b/autonomx/GeneratorLatticeCommunicator.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <QObject>
+#include <QSharedPointer>
 
 #include "Generator.h"
 
@@ -23,13 +24,13 @@ class GeneratorLatticeCommunicator : public QObject {
     Q_OBJECT
 public:
     GeneratorLatticeCommunicator();
-    void updateGenerator(Generator* generator);
+    void updateGenerator(QSharedPointer<Generator> generator);
     void writeLatticeData(float** latticeData, int* allocatedWidth, int* allocatedHeight);
 
     bool isCurrentRequestDone();
     bool isFirstRequestDone();
 private:
-    Generator* generator = nullptr;
+    QSharedPointer<Generator> generator = nullptr;
     bool currentRequestDone = true;
     bool firstRequestDone = false;
     bool flagDebug = false;

--- a/autonomx/GeneratorLatticeRenderer.cpp
+++ b/autonomx/GeneratorLatticeRenderer.cpp
@@ -52,7 +52,7 @@ GeneratorLatticeRenderer::GeneratorLatticeRenderer() : QQuickFramebufferObject::
     allocatedWidth = new int(0);
     allocatedHeight = new int(0);
 
-    // get texture name
+    // get texture
     functions->glGenTextures(1, &texture);
 }
 
@@ -76,6 +76,8 @@ GeneratorLatticeRenderer::~GeneratorLatticeRenderer() {
             delete framebufferSuper;
         }
     }
+    // delete texture
+    functions->glDeleteTextures(1, &texture);
 }
 
 void GeneratorLatticeRenderer::render() {

--- a/autonomx/GeneratorLatticeRenderer.h
+++ b/autonomx/GeneratorLatticeRenderer.h
@@ -21,6 +21,7 @@
 #include <QOpenGLShaderProgram>
 #include <QOpenGLFramebufferObject>
 #include <QQuickWindow>
+#include <QSharedPointer>
 
 #include "Generator.h"
 #include "GeneratorLatticeCommunicator.h"
@@ -47,8 +48,8 @@ private:
     bool flagSuper = true;                  // enables supersampling
     bool flagDebug = false;                 // enables debug
     int generatorID;                        // associated generator id
-    Generator* generator;                   // associated generator
-    GeneratorLatticeCommunicator* communicator;
+    QSharedPointer<Generator> generator;    // associated generator
+    GeneratorLatticeCommunicator communicator;
     float** latticeData;        // the lattice data used to draw the graphics
     int* allocatedWidth;        // the width of allocated flattened array in the memory block pointed by latticeData
     int* allocatedHeight;       // the height of allocated flattened array in the memory block pointed by latticeData

--- a/autonomx/OscEngine.cpp
+++ b/autonomx/OscEngine.cpp
@@ -80,40 +80,40 @@ void OscEngine::startGeneratorOsc(QSharedPointer<Generator> generator) {
     createOscSender(id, addressSenderHost, addressSenderTarget, portSender);
 
     // connect input / receiver changes
-    QObject::connect(generator.data(), &Generator::oscInputAddressChanged, this, [this, generator](QString oscInputAddress){
+    QObject::connect(generator.data(), &Generator::oscInputAddressChanged, this, [this, id](QString oscInputAddress){
         if(flagDebug) {
             qDebug() << "oscInputAddressChanged (lambda)";
         }
-        emit updateOscReceiverAddress(generator->getID(), oscInputAddress);
+        emit updateOscReceiverAddress(id, oscInputAddress);
     });
 
-    QObject::connect(generator.data(), &Generator::oscInputPortChanged, this, [this, generator](int oscInputPort){
+    QObject::connect(generator.data(), &Generator::oscInputPortChanged, this, [this, id](int oscInputPort){
         if(flagDebug) {
             qDebug() << "oscInputPortChanged (lambda)";
         }
-        emit updateOscReceiverPort(generator->getID(), oscInputPort);
+        emit updateOscReceiverPort(id, oscInputPort);
     });
 
     // connect output / sender changes
-    QObject::connect(generator.data(), &Generator::oscOutputAddressHostChanged, this, [this, generator](QString oscOutputAddressHost){
+    QObject::connect(generator.data(), &Generator::oscOutputAddressHostChanged, this, [this, id](QString oscOutputAddressHost){
         if(flagDebug) {
             qDebug() << "oscOutputAddressHostChanged (lambda)";
         }
-        emit updateOscSenderAddressHost(generator->getID(), oscOutputAddressHost);
+        emit updateOscSenderAddressHost(id, oscOutputAddressHost);
     });
 
-    QObject::connect(generator.data(), &Generator::oscOutputAddressTargetChanged, this, [this, generator](QString oscOutputAddressTarget){
+    QObject::connect(generator.data(), &Generator::oscOutputAddressTargetChanged, this, [this, id](QString oscOutputAddressTarget){
         if(flagDebug) {
             qDebug() << "oscOutputAddressTargetChanged (lambda)";
         }
-        emit updateOscSenderAddressTarget(generator->getID(), oscOutputAddressTarget);
+        emit updateOscSenderAddressTarget(id, oscOutputAddressTarget);
     });
 
-    QObject::connect(generator.data(), &Generator::oscOutputPortChanged, this, [this, generator](int oscOutputPort){
+    QObject::connect(generator.data(), &Generator::oscOutputPortChanged, this, [this, id](int oscOutputPort){
         if(flagDebug) {
             qDebug() << "oscOutputAddressTargetChanged (lambda)";
         }
-        emit updateOscSenderPort(generator->getID(), oscOutputPort);
+        emit updateOscSenderPort(id, oscOutputPort);
     });
 }
 

--- a/autonomx/components/ui/GeneratorWidget.qml
+++ b/autonomx/components/ui/GeneratorWidget.qml
@@ -17,7 +17,6 @@ Button {
     onSelectedChanged: {
         if (selected) {
             forceActiveFocus();
-            generatorList.positionViewAtIndex(window.activeGeneratorIndex, ListView.SnapPosition)
         }
     }
 

--- a/autonomx/layout/GeneratorList.qml
+++ b/autonomx/layout/GeneratorList.qml
@@ -28,10 +28,7 @@ Item {
             Layout.fillHeight: true
 
             orientation: Qt.Vertical
-            //boundsBehavior: Flickable.StopAtBounds
-            highlightRangeMode: ListView.ApplyRange
-            preferredHighlightBegin: 40
-            preferredHighlightEnd: height - 40
+            boundsBehavior: Flickable.StopAtBounds
             ScrollBar.vertical: ScrollBar {
                 interactive: false
             }

--- a/autonomx/layout/LatticeView.qml
+++ b/autonomx/layout/LatticeView.qml
@@ -131,7 +131,7 @@ RowLayout {
 
             visible: generatorIndex < 0
 
-            text: qsTr("Please select a generator from the Generator View to edit its I/O zones.")
+            text: qsTr("Select a generator from the left panel to visualize and edit it.")
             wrapMode: Text.WordWrap
             horizontalAlignment: Text.AlignHCenter
             font.pixelSize: 14

--- a/autonomx/main.cpp
+++ b/autonomx/main.cpp
@@ -79,7 +79,7 @@ int main(int argc, char *argv[]) {
 
     // Pass C++ objects to QML.
     qmlEngine.rootContext()->setContextProperty("appModel", &AppModel::getInstance());
-    qmlEngine.rootContext()->setContextProperty("generatorModel", AppModel::getInstance().getGeneratorModel());
+    qmlEngine.rootContext()->setContextProperty("generatorModel", AppModel::getInstance().getGeneratorModel().data());
     qmlEngine.load(QUrl(QStringLiteral("qrc:/main.qml")));
     if (qmlEngine.rootObjects().isEmpty())
         return -1;


### PR DESCRIPTION
- This fixes two memory leaks (texture not beeing freed when `GeneratorLatticeRenderer` was deleted and `Generator` never being deallocated when removed). 
- This also fixes edge glitches on the sides of the history graph. 
- The scroll jump when selecting a generator was removed as it was a jarring — it made it hard to track where the generators moved to. If sometime in the future we can re-implement this to only activate when adding new generators that appear out of frame (maybe with a short transition animation), but not when selecting generators, that would be ideal, but for now I believe this is the best. 
- The «no lattice selected» text in `LatticeView.qml` was updated to reflect the fact that Lattice View / Generator View are no longer a thing.