### PR TITLE
Tweak SNN learning parameters

### DIFF
--- a/autonomx/SpikingNet.cpp
+++ b/autonomx/SpikingNet.cpp
@@ -575,8 +575,8 @@ double SpikingNet::getSTDPStrength() const {
     return this->STDPStrength;
 }
 
-double SpikingNet::getDecayConstant() const {
-    return this->decayConstant;
+double SpikingNet::getDecayHalfLife() const {
+    return this->decayHalfLife;
 }
 
 bool SpikingNet::getFlagSTP() const {
@@ -750,8 +750,8 @@ void SpikingNet::writeSTDPStrength(double STDPStrength) {
     emit STDPStrengthChanged(STDPStrength);
 }
 
-void SpikingNet::writeDecayConstant(double decayConstant) {
-    if(this->decayConstant == decayConstant)
+void SpikingNet::writeDecayHalfLife(double decayHalfLife) {
+    if(this->decayHalfLife == decayHalfLife)
         return;
 
     if(flagDebug) {
@@ -762,9 +762,10 @@ void SpikingNet::writeDecayConstant(double decayConstant) {
         qDebug() << "writeDecayConstant:\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
     }
 
-    this->decayConstant = decayConstant;
-    emit valueChanged("decayConstant", QVariant(decayConstant));
-    emit decayConstantChanged(decayConstant);
+    this->decayHalfLife = decayHalfLife;
+    decayConstant = std::pow(2.0, - 1.0 / decayHalfLife);
+    emit valueChanged("decayHalfLife", QVariant(decayHalfLife));
+    emit decayHalfLifeChanged(decayHalfLife);
 }
 
 void SpikingNet::writeFlagSTP(bool flagSTP) {

--- a/autonomx/SpikingNet.h
+++ b/autonomx/SpikingNet.h
@@ -33,7 +33,7 @@ class SpikingNet : public Generator {
 
     Q_PROPERTY(double STPStrength READ getSTPStrength WRITE writeSTPStrength NOTIFY STPStrengthChanged)
     Q_PROPERTY(double STDPStrength READ getSTDPStrength WRITE writeSTDPStrength NOTIFY STDPStrengthChanged)
-    Q_PROPERTY(double decayConstant READ getDecayConstant WRITE writeDecayConstant NOTIFY decayConstantChanged)
+    Q_PROPERTY(double decayHalfLife READ getDecayHalfLife WRITE writeDecayHalfLife NOTIFY decayHalfLifeChanged)
 
     Q_PROPERTY(bool flagSTP READ getFlagSTP WRITE writeFlagSTP NOTIFY flagSTPChanged)
     Q_PROPERTY(bool flagSTDP READ getFlagSTDP WRITE writeFlagSTDP NOTIFY flagSTDPChanged)
@@ -69,7 +69,8 @@ private:
     double      weightMax = 20.0;
     double      weightMin = 0.0;
 
-    double      decayConstant = 0.9995;
+    double      decayHalfLife = 10.0;
+    double      decayConstant = std::pow(2.0, - 1.0 / decayHalfLife);
 
     double      timeScale = 30.0 / 1000.0;
 
@@ -77,7 +78,7 @@ private:
     double STPStrength = 1.0;
 
     bool        flagSTP                 = false;
-    bool        flagSTDP                = true;
+    bool        flagSTDP                = false;
     bool        flagDecay               = false;
     bool        flagDirectConnection    = true;
     bool        flagRandomDevice        = true;
@@ -135,7 +136,7 @@ public:
     double getExcitatoryNoise() const;
     double getSTPStrength() const;
     double getSTDPStrength() const;
-    double getDecayConstant() const;
+    double getDecayHalfLife() const;
     bool getFlagSTP() const;
     bool getFlagSTDP() const;
     bool getFlagDecay() const;
@@ -149,7 +150,7 @@ public:
     void writeExcitatoryNoise(double excitatoryNoise);
     void writeSTPStrength(double STPStrength);
     void writeSTDPStrength(double STDPStrength);
-    void writeDecayConstant(double decayConstant);
+    void writeDecayHalfLife(double decayHalfLife);
     void writeFlagSTP(bool flagSTP);
     void writeFlagSTDP(bool flagSTDP);
     void writeFlagDecay(bool flagDecay);
@@ -169,7 +170,7 @@ signals:
     void excitatoryNoiseChanged(double excitatoryNoise);
     void STPStrengthChanged(double STPStrength);
     void STDPStrengthChanged(double STDPStrength);
-    void decayConstantChanged(double decayConstant);
+    void decayHalfLifeChanged(double decayHalfLife);
     void flagSTPChanged(bool flagSTP);
     void flagSTDPChanged(bool flagSTDP);
     void flagDecayChanged(bool flagDecay);

--- a/autonomx/components/racks/SNNParametersRack.qml
+++ b/autonomx/components/racks/SNNParametersRack.qml
@@ -67,14 +67,12 @@ ColumnLayout {
                 propName: "inhibitoryNoise"
                 minVal: 0.0
                 maxVal: 50.0
-                updateLag: 70
             },
             SliderField {
                 labelText: "Exc. neuron noise"
                 propName: "excitatoryNoise"
                 minVal: 0.0
                 maxVal: 50.0
-                updateLag: 70
             },
             SliderField {
                 labelText: "Inh. portion"
@@ -104,22 +102,21 @@ ColumnLayout {
                 propName: "STPStrength"
                 flagName: "flagSTP"
                 minVal: 0.0
-                maxVal: 10.0
-                updateLag: 70
+                maxVal: 30.0
             },
             SliderField {
                 labelText: "STDP strength"
                 propName: "STDPStrength"
                 flagName: "flagSTDP"
                 minVal: 0.0
-                maxVal: 10.0
-                updateLag: 70
+                maxVal: 30.0
             },
             SliderField {
-                labelText: "Decay constant"
-                propName: "decayConstant"
+                labelText: "Decay half life"
+                propName: "decayHalfLife"
                 flagName: "flagDecay"
-                updateLag: 70
+                minVal: 0.1
+                maxVal: 60.0
             }
 
         ]

--- a/autonomx/components/racks/SNNParametersRack.qml
+++ b/autonomx/components/racks/SNNParametersRack.qml
@@ -103,12 +103,16 @@ ColumnLayout {
                 labelText: "STP strength"
                 propName: "STPStrength"
                 flagName: "flagSTP"
+                minVal: 0.0
+                maxVal: 10.0
                 updateLag: 70
             },
             SliderField {
                 labelText: "STDP strength"
                 propName: "STDPStrength"
                 flagName: "flagSTDP"
+                minVal: 0.0
+                maxVal: 10.0
                 updateLag: 70
             },
             SliderField {


### PR DESCRIPTION
This PR widens the range of the STP and STDP learning parameters for better usability, and changes the way the decay rate of the connections is controlled. Rather than a hard to control decay constant (the scalar that represents the decay over a second), the decay is now expressed as the half-life time (in seconds) of the connection. This maps the parameter curve in a much more useful way, and is more intuitive to the user.