### PR TITLE
Add a macOS release scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,16 @@ qmake ..
 make
 ```
 
+### macOS app bundle
+
+To create the macOS app bundle, run this script:
+
+```
+./scripts/sh_mac_deploy_qt.sh
+```
+
+You might need to manually edit these scripts in order to configure the version number of Qt you have installed.
+
 # Coding style
 
 We follow the [Qt style guide](https://wiki.qt.io/Qt_Coding_Style) for C++ and QML.

--- a/scripts/sh_mac_deploy_qt.sh
+++ b/scripts/sh_mac_deploy_qt.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Builds the app with macdeployqt
+# before running this script, build the app in Qt Creator with the Release configuration.
+# (or with qmake)
+# Next, run this script in order to include all the frameworks it needs into the .app bundle.
+
+cd $(dirname ${0})/..
+
+QT_VERSION_UNDERSCORE=5_12_11
+QT_VERSION_DOTTED=5.12.11
+PATH_TO_QT_BIN=~/Qt/${QT_VERSION_DOTTED}/clang_64/bin
+PATH_TO_RELEASE_DOT_APP=../build-autonomx-Desktop_Qt_${QT_VERSION_UNDERSCORE}_clang_64bit-Release/autonomx/autonomx.app
+PATH_TO_QML_DIR=./autonomx
+
+${PATH_TO_QT_BIN}/macdeployqt ${PATH_TO_RELEASE_DOT_APP} -qmldir=${PATH_TO_QML_DIR} -verbose=3
+

--- a/scripts/sh_run_build_macos.sh
+++ b/scripts/sh_run_build_macos.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Smoke tests the application by simply running it.
+
+cd $(dirname ${0})/..
+
+QT_VERSION_UNDERSCORE=5_12_11
+PATH_TO_RELEASE_DOT_APP=./build-autonomx-Desktop_Qt_${QT_VERSION_UNDERSCORE}_clang_64bit-Release/autonomx/autonomx.app
+EXEC_NAME=autonomx
+
+${PATH_TO_RELEASE_DOT_APP}/Contents/MacOS/${EXEC_NAME}
+


### PR DESCRIPTION
This adds two simple scripts; one for running macdeployqt to package dependencies into the app, and one to run the build with a debug output.

Related to https://github.com/Xmodal/autonomX/issues/177 and #288 

Closes #288