### PR TITLE
add backend functionality for the "Reset params" button

### DIFF
--- a/autonomx/Generator.cpp
+++ b/autonomx/Generator.cpp
@@ -290,6 +290,36 @@ void Generator::writeLatticeHeight(int latticeHeight) {
     emit latticeHeightChanged(latticeHeight);
 }
 
+void Generator::resetParameters()
+{
+    const QMetaObject *metaObject = this->metaObject();
+
+    for (int i = metaObject->indexOfProperty("latticeWidth"); i < metaObject->propertyCount(); i++) {
+        // get property object
+        QMetaProperty metaProperty = metaObject->property(i);
+
+        // TODO: flags need a different validation system
+        // (hint: trim down w/o the "flag" prefix)
+
+        // find associated default value for given property in the meta tree
+        for (GeneratorField* f : meta->getFields()) {
+            if (f->propName == metaProperty.name()) {
+                // write default value to property
+                // TODO: doesn't work with selects/enums yet
+                metaProperty.write(this, f->defaultValue);
+
+                // break to next field
+                break;
+            }
+        }
+    }
+
+    // TODO: reset input/output zones as well...?
+
+    // re-initialize
+    initialize();
+}
+
 void Generator::updateValue(const QString &key, const QVariant &value) {
     // qDebug() << "Generator::updateValue";
 

--- a/autonomx/Generator.h
+++ b/autonomx/Generator.h
@@ -126,7 +126,7 @@ public:
 
     // reinitialize generator
     virtual void initialize() = 0;
-    virtual void resetParameters() = 0;
+    void resetParameters();
 
     // this updates the lattice / region from the corresponding region / lattice. this is called before / after the call to computeIteration from ComputeEngine
     void applyInputRegion();

--- a/autonomx/GeneratorField.h
+++ b/autonomx/GeneratorField.h
@@ -31,6 +31,9 @@ struct GeneratorField {
     Q_PROPERTY(bool restartOnEdit MEMBER restartOnEdit)
     Q_PROPERTY(bool flag MEMBER flag)
 
+    Q_PROPERTY(QVariant defaultValue MEMBER defaultValue)
+    Q_PROPERTY(bool flagDefaultValue MEMBER flagDefaultValue)
+
     Q_PROPERTY(QString placeholder MEMBER placeholder)
     Q_PROPERTY(QVariant min MEMBER min)
     Q_PROPERTY(QVariant max MEMBER max)
@@ -46,6 +49,9 @@ public:
             bool restartOnEdit,
             bool flag,
 
+            QVariant defaultValue,
+            bool flagDefaultValue,
+
             QString placeholder,
             QVariant min,
             QVariant max,
@@ -56,6 +62,9 @@ public:
           type(type),
           restartOnEdit(restartOnEdit),
           flag(flag),
+
+          defaultValue(defaultValue),
+          flagDefaultValue(flagDefaultValue),
 
           placeholder(placeholder),
           min(min),
@@ -70,6 +79,9 @@ public:
         restartOnEdit = fieldProps["restartOnEdit"].toBool();
         flag = fieldProps["flag"].toBool();
 
+        defaultValue = fieldProps["default"];
+        flagDefaultValue = fieldProps["flagDefault"].toBool();
+
         placeholder = fieldProps["placeholder"].toString();
         min = fieldProps["min"];
         max = fieldProps["max"];
@@ -81,6 +93,9 @@ public:
     QString type;
     bool restartOnEdit = false;
     bool flag = false;
+
+    QVariant defaultValue;
+    bool flagDefaultValue;
 
     // field-specific
     QString placeholder = "";

--- a/autonomx/GeneratorMeta.cpp
+++ b/autonomx/GeneratorMeta.cpp
@@ -29,6 +29,11 @@ QString GeneratorMeta::getDescription() const
     return description;
 }
 
+QList<GeneratorField*> GeneratorMeta::getFields() const
+{
+    return fields;
+}
+
 QVariantMap GeneratorMeta::getFieldTree() const
 {
     return fieldTree;
@@ -102,9 +107,13 @@ void GeneratorMeta::registerMeta() {
                 fieldProps[keys[k]] = fieldData[keys[k]].toVariant();
             }
 
-            // apply all default and new values to new instance of GeneratorField
-            // and insert into SubRack vector
-            rackStr.append(QVariant::fromValue(GeneratorField(fieldProps)));
+            // apply all default and new values to a new instance of GeneratorField
+            GeneratorField* newField = new GeneratorField(fieldProps);
+
+            // append to single-leveled field list
+            fields.append(newField);
+            // append to multi-leveled field tree
+            rackStr.append(QVariant::fromValue(*newField));
         }
 
         // insert SubRack vector into the field tree
@@ -133,10 +142,10 @@ void GeneratorMeta::registerMeta() {
             continue;
         }
 
+        // read from file
+        QString htmlContent = helpHtml.readAll();
         // insert as entry in rack
         // again, index to order
-        QString htmlContent = helpHtml.readAll();
-
         QString index = QStringLiteral("%1").arg(i, 2, 10, QLatin1Char('0'));
         helpRacks.insert(index + "_" + title, htmlContent);
 

--- a/autonomx/GeneratorMeta.h
+++ b/autonomx/GeneratorMeta.h
@@ -23,6 +23,10 @@ class GeneratorMeta : public QObject
     QString type;
     QString description;
 
+    // used by resetParameters()
+    // and hopefully other things too!
+    QList<GeneratorField*> fields;
+
     // meta trees
     QVariantMap fieldTree;
     QVariantMap helpRacks;
@@ -74,6 +78,8 @@ public:
     QString getName() const;
     QString getType() const;
     QString getDescription() const;
+
+    QList<GeneratorField*> getFields() const;
 
     QVariantMap getFieldTree() const;
     QVariantMap getHelpRacks() const;

--- a/autonomx/SpikingNet.cpp
+++ b/autonomx/SpikingNet.cpp
@@ -749,7 +749,7 @@ void SpikingNet::writeFlagSTP(bool flagSTP) {
     }
 
     this->flagSTP = flagSTP;
-    emit valueChanged("flagSTP", QVariant(flagSTP));
+    emit valueChanged("flag_STPStrength", QVariant(flagSTP));
     emit flagSTPChanged(flagSTP);
 }
 
@@ -766,7 +766,7 @@ void SpikingNet::writeFlagSTDP(bool flagSTDP) {
     }
 
     this->flagSTDP = flagSTDP;
-    emit valueChanged("flagSTDP", QVariant(flagSTDP));
+    emit valueChanged("flag_STDPStrength", QVariant(flagSTDP));
     emit flagSTDPChanged(flagSTDP);
 }
 
@@ -783,7 +783,7 @@ void SpikingNet::writeFlagDecay(bool flagDecay) {
     }
 
     this->flagDecay = flagDecay;
-    emit valueChanged("flagDecay", QVariant(flagDecay));
+    emit valueChanged("flag_decayHalfLife", QVariant(flagDecay));
     emit flagDecayChanged(flagDecay);
 }
 

--- a/autonomx/SpikingNet.cpp
+++ b/autonomx/SpikingNet.cpp
@@ -123,12 +123,6 @@ void SpikingNet::initialize() {
     // qDebug() << "initialized";
 }
 
-void SpikingNet::resetParameters()
-{
-    // reset parameters here
-
-    // qDebug() << "parameters reset";
-}
 
 // inhibitory neurons are first, the rest is excitatory neurons
 // input and output neurons are always in the excitatory neurons

--- a/autonomx/SpikingNet.cpp
+++ b/autonomx/SpikingNet.cpp
@@ -31,6 +31,8 @@ SpikingNet::SpikingNet(int id, GeneratorMeta * meta) : Generator(id, meta)
         qDebug() << "constructor (SpikingNet):\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
     }
 
+    // make sure these two functions are ALWAYS called at the end of a constructor!
+    resetParameters();
     initialize();
 }
 

--- a/autonomx/SpikingNet.h
+++ b/autonomx/SpikingNet.h
@@ -37,9 +37,9 @@ class SpikingNet : public Generator {
     Q_PROPERTY(double STDPStrength READ getSTDPStrength WRITE writeSTDPStrength NOTIFY STDPStrengthChanged)
     Q_PROPERTY(double decayHalfLife READ getDecayHalfLife WRITE writeDecayHalfLife NOTIFY decayHalfLifeChanged)
 
-    Q_PROPERTY(bool flagSTPStrength READ getFlagSTP WRITE writeFlagSTP NOTIFY flagSTPChanged)
-    Q_PROPERTY(bool flagSTDPStrength READ getFlagSTDP WRITE writeFlagSTDP NOTIFY flagSTDPChanged)
-    Q_PROPERTY(bool flagDecayHalfLife READ getFlagDecay WRITE writeFlagDecay NOTIFY flagDecayChanged)
+    Q_PROPERTY(bool flag_STPStrength READ getFlagSTP WRITE writeFlagSTP NOTIFY flagSTPChanged)
+    Q_PROPERTY(bool flag_STDPStrength READ getFlagSTDP WRITE writeFlagSTDP NOTIFY flagSTDPChanged)
+    Q_PROPERTY(bool flag_decayHalfLife READ getFlagDecay WRITE writeFlagDecay NOTIFY flagDecayChanged)
 
 // enum
 public:

--- a/autonomx/SpikingNet.h
+++ b/autonomx/SpikingNet.h
@@ -125,7 +125,6 @@ public:
 
     void computeIteration(double deltaTime) override;
     void initialize() override;
-    void resetParameters() override;
     double getLatticeValue(int x, int y) override;
     void writeLatticeValue(int x, int y, double value) override;
 

--- a/autonomx/WolframCA.cpp
+++ b/autonomx/WolframCA.cpp
@@ -86,12 +86,6 @@ else{
     generate(r);
 }
 
-void WolframCA::resetParameters()
-{
-    // reset params here
-    initialize();
-}
-
 void WolframCA::computeIteration(double deltaTime)
 {
     //set ruleset using the determined rule after checking if the rule has changed by the user

--- a/autonomx/WolframCA.h
+++ b/autonomx/WolframCA.h
@@ -72,7 +72,6 @@ public:
     // overrides / implementing necessary virtual functions from Generator class
     void computeIteration(double deltaTime) override;
     void initialize() override;
-    void resetParameters() override;
     double getLatticeValue(int x, int y) override;
     void writeLatticeValue(int x, int y, double value) override;
     double sigmoid(double value);

--- a/autonomx/components/fields/Field.qml
+++ b/autonomx/components/fields/Field.qml
@@ -22,7 +22,7 @@ ColumnLayout {
     property real frameMaskWidth: 0
     // flag props
     property string flagName: ""
-    property bool flagValue: flagName !== "" && generatorModel.at(window.activeGeneratorIndex) ? generatorModel.at(window.activeGeneratorIndex)[flagName] : false
+    property bool flagValue: flagName !== "" && generatorModel.at(activeGeneratorIndex) ? generatorModel.at(activeGeneratorIndex)[flagName] : false
     property bool activated: flagName !== "" ? flag.checked : true
     // field prop
     property alias fieldContent: fieldContentLoader.sourceComponent
@@ -31,8 +31,8 @@ ColumnLayout {
     signal valueChanged(variant newValue)
     signal flagChanged(bool newFlag)
 
-    onValueChanged: if (generatorModel.at(window.activeGeneratorIndex)) generatorModel.at(window.activeGeneratorIndex)[propName] = newValue
-    onFlagChanged: if (generatorModel.at(window.activeGeneratorIndex)) generatorModel.at(activeGeneratorIndex)[flagName] = newFlag
+    onValueChanged: if (generatorModel.at(activeGeneratorIndex)) generatorModel.at(activeGeneratorIndex)[propName] = newValue
+    onFlagChanged: if (generatorModel.at(activeGeneratorIndex)) generatorModel.at(activeGeneratorIndex)[flagName] = newFlag
 
     // layout
     implicitWidth: fieldWidth

--- a/autonomx/components/racks/ParametersRack.qml
+++ b/autonomx/components/racks/ParametersRack.qml
@@ -59,7 +59,7 @@ ColumnLayout {
 
                     // flag property
                     if (field.flag) {
-                        props.flagName = "flag" + field.propName.charAt(0).toUpperCase() + field.propName.slice(1);
+                        props.flagName = "flag_" + field.propName;
                     }
 
                     // determine field type

--- a/autonomx/generators/README.md
+++ b/autonomx/generators/README.md
@@ -25,6 +25,7 @@ The structure of the enclosed JSON object is as follows:
                     "label": "Field #1",
                     "propName": "field1",
                     "type": "number",
+                    "default": 10
                     ...
                 },
                 ...
@@ -64,8 +65,10 @@ This property is defined as an array of objects, each representing its own `SubR
 When defining a new field object, consider the following:
 - `label`, `propName` and `type` are **required**;
 - `propName` refers to the name of the `Q_PROPERTY` that you've exposed in your `Generator` sub-class beforehand. Make sure that this refers to the *property name*, and not the private member it points to. Also make sure that this property has at least a `READ [method]` declaration in its macro definition, so that it can be effectively read from QML;
+- `default` refers to the default value you want this property to initialize at, with its data type reflecting the field type you've previously chosen;
 - `type` refers to the field type that should be displayed in the GUI. Other required properties need to be provided depending on which type you choose here (see below for field type options);
-- a `flag` property can be provided if you want to allow your parameter to be deactivated. In the `GeneratorMeta` registration process, the associated boolean `Q_PROPERTY` name is understood as **the value of `propName` prefixed by `flag`, camel-cased**. For example, the flag's property name for `"propName": "myProperty"` would be `flagMyProperty`.
+- a `flag` property can be provided if you want to allow your parameter to be deactivated. In the `GeneratorMeta` registration process, the associated boolean `Q_PROPERTY` name is understood as **the value of `propName` prefixed by `flag`, camel-cased**. For example, the flag's property name for `"propName": "myProperty"` would be `flagMyProperty`;
+- a `flagDefault` boolean property (only necessary if `flag` is set to `true`, to determine) that defines the default value of the flag checkbox.
 
 A static hash map containing the default values for field declarations is defined in `GeneratorMeta::fieldDefaults`.
 
@@ -85,18 +88,21 @@ For further information on how to prepare `enum`s for full-stack use, refer to "
 
 ## Field type options
 Here are the possible values for `type`, followed by the required properties you need to provide for these types:
-- `"number"`: integer value field; `"min": int, "max": int`;
+- `"number"`: int value field; `"min": int, "max": int`;
 - `"slider"`: float value field; `"min": float, "max": float`;
-- `"select"`: choice selection field; `"enumName": string`;
+- `"select"`: choice selection field; `"enumName": int`;
 - `"text"`: single-line text field; `"placeholder": string`;
-- `"area"`: multi-line text field; `"placeholder": string`.
+- `"area"`: multi-line text field; `"placeholder": string`.<
+
+Please note that `select` fields accept an **integer value**, and not a string value; less so an actual enum identifier. This is to facilitate parsing in C++, which is very strict on the ways you can access enum values. When defining a default value for such a field, make sure that the index you input here corresponds to the index of the enum you're trying to target back in C++.
 
 ## Tying it all back to C++
 
 In order for these files to be recognized by the software architecture, they need to be explicitly brought into the `GeneratorMetaModel`, as well as have its concurring class types exposed to QML:
 - in `main.cpp`, at around L.83, add a call to `qmlRegisterUncreatableType`, passing in the new Generator sub-class as a template argument and its string-ified name as the 4th argument (refer to existing calls);
 - in the constructor of `AppModel.cpp`, at L.50, add a call to `insertAtEnd`, passing in the generator type argument previously mentioned;
-- in `AppModel::createGenerator`, L.158: add a switch case for your new Generator sub-class, following the pre-existing declarations and replacing appropriate string values by the same generator type argument identifier.
+- in `AppModel::createGenerator`, L.158: add a switch case for your new Generator sub-class, following the pre-existing declarations and replacing appropriate string values by the same generator type argument identifier;
+- (optional) unless you're already defining the same default values inline of your header file, **make sure you're calling `resetParameters()` at the end of your constructor**, so that the values inside `meta.json` are effectively applied at first initialization.
 
 ### Additional configuration for `enum`s
 In the case of `enum` declarations, some extra steps need to be taken. For every new `enum` you bring into the application, we **strongly** recommend you place it inside its own header file, then including it in your .cpp files wherever necessary.

--- a/autonomx/generators/SpikingNet/meta.json
+++ b/autonomx/generators/SpikingNet/meta.json
@@ -12,20 +12,23 @@
                     "propName": "latticeWidth",
                     "type": "number",
                     "min": 1,
-                    "max": 1000
+                    "max": 1000,
+                    "default": 20
                 },
                 {
                     "label": "Height",
                     "propName": "latticeHeight",
                     "type": "number",
                     "min": 1,
-                    "max": 1000
+                    "max": 1000,
+                    "default": 20
                 },
                 {
                     "label": "Time scale",
                     "propName": "timeScale",
                     "type": "slider",
-                    "max": 0.03
+                    "max": 0.03,
+                    "default": 0.03
                 }
             ]
         },
@@ -36,30 +39,35 @@
                     "label": "Inh. neuron noise",
                     "propName": "inhibitoryNoise",
                     "type": "slider",
-                    "max": 50
+                    "max": 50,
+                    "default": 3
                 },
                 {
                     "label": "Exc. neuron noise",
                     "propName": "excitatoryNoise",
                     "type": "slider",
-                    "max": 50
+                    "max": 50,
+                    "default": 5
                 },
                 {
                     "label": "Inh. portion",
                     "propName": "inhibitoryPortion",
-                    "type": "slider"
+                    "type": "slider",
+                    "default": 0.2
                 },
                 {
                     "label": "Inh. neuron type",
                     "propName": "inhibitoryNeuronType",
                     "type": "select",
-                    "enumName": "NeuronType"
+                    "enumName": "NeuronType",
+                    "default": "ChatteringNeuron"
                 },
                 {
                     "label": "Exc. neuron type",
                     "propName": "excitatoryNeuronType",
                     "type": "select",
-                    "enumName": "NeuronType"
+                    "enumName": "NeuronType",
+                    "default": "ChatteringNeuron"
                 }
             ]
         },
@@ -71,14 +79,18 @@
                     "propName": "STPStrength",
                     "type": "slider",
                     "flag": true,
-                    "max": 30
+                    "max": 30,
+                    "default": 1,
+                    "flagDefault": false
                 },
                 {
                     "label": "STDP strength",
                     "propName": "STDPStrength",
                     "type": "slider",
                     "flag": true,
-                    "max": 30
+                    "max": 30,
+                    "default": 1,
+                    "flagDefault": false
                 },
                 {
                     "label": "Decay half life",
@@ -86,7 +98,9 @@
                     "type": "slider",
                     "flag": true,
                     "min": 0.1,
-                    "max": 60
+                    "max": 60,
+                    "default": 10,
+                    "flagDefault": false
                 }
             ]
         }

--- a/autonomx/generators/SpikingNet/meta.json
+++ b/autonomx/generators/SpikingNet/meta.json
@@ -60,14 +60,14 @@
                     "propName": "inhibitoryNeuronType",
                     "type": "select",
                     "enumName": "NeuronType",
-                    "default": "ChatteringNeuron"
+                    "default": 4
                 },
                 {
                     "label": "Exc. neuron type",
                     "propName": "excitatoryNeuronType",
                     "type": "select",
                     "enumName": "NeuronType",
-                    "default": "ChatteringNeuron"
+                    "default": 4
                 }
             ]
         },


### PR DESCRIPTION
closes #236.

this PR implements generic behaviour for the previously blank "Reset params" button. it functions as a `QMetaObject` traverser, writing default values inscribed in the `meta.json` file sequentially to their associated Qt properties. since the Qt system is being used here, the process is fairly simple and akin to editing all values in the GUI at once, so no big change to the architecture has been brought in as a result.