### PR TITLE
implement rudimentary save/load functionalities

### DIFF
--- a/autonomx/AppModel.cpp
+++ b/autonomx/AppModel.cpp
@@ -329,7 +329,8 @@ bool AppModel::saveProject(QString uri) {
     // write all data
     writeJson(saveObject);
     // save to file
-    saveFile.write(QJsonDocument(saveObject).toJson());
+    // saveFile.write(QJsonDocument(saveObject).toJson(QJsonDocument::Compact));
+    saveFile.write(QJsonDocument(saveObject).toJson(QJsonDocument::Indented));
 
     // success
     return true;
@@ -354,10 +355,27 @@ QSharedPointer<GeneratorMetaModel> AppModel::getGeneratorMetaModel() const
 
 void AppModel::readJson(const QJsonObject &json)
 {
-    qDebug() << json["test"];
+    qDebug() << json["version"];
 }
 
 void AppModel::writeJson(QJsonObject &json) const
 {
-    json["test"] = "yo :)";
+    std::time_t now = std::time(0);
+
+    json["version"] = QCoreApplication::applicationVersion();
+    json["savedAt"] = now;
+
+    // TODO: OSC I/O port numbers + send host
+
+    // write generator data
+    QJsonArray generatorData;
+
+    for (QSharedPointer<Generator> g : *generatorsList) {
+        QJsonObject singleGeneratorData;
+        g->writeJson(singleGeneratorData);
+        generatorData.append(singleGeneratorData);
+    }
+
+    // add to global JSON
+    json["generators"] = generatorData;
 }

--- a/autonomx/AppModel.cpp
+++ b/autonomx/AppModel.cpp
@@ -119,7 +119,7 @@ QSharedPointer<QThread> AppModel::getOscThread() const {
     return oscThread;
 }
 
-QSharedPointer<ComputeEngine>  AppModel::getComputeEngine() const {
+QSharedPointer<ComputeEngine> AppModel::getComputeEngine() const {
     return computeEngine;
 }
 
@@ -286,6 +286,55 @@ bool AppModel::validateNewGeneratorName(QString name) {
     return valid;
 }
 
+bool AppModel::loadProject(QString uri)
+{
+    // parse URI
+    QUrl url(uri);
+    // create QFile at URI
+    QFile loadFile(url.toLocalFile());
+
+    // try to open file
+    if (!loadFile.open(QIODevice::ReadOnly)) {
+        qWarning() << "Couldn't open save file:" << uri;
+        return false;
+    }
+
+    // read file
+    QByteArray saveData = loadFile.readAll();
+
+    // convert to JSON document
+    QJsonDocument loadDoc(QJsonDocument::fromJson(saveData));
+
+    // read data
+    readJson(loadDoc.object());
+
+    // success!
+    return true;
+}
+
+bool AppModel::saveProject(QString uri) {
+    // parse URI
+    QUrl url(uri);
+    // create QFile at URL
+    QFile saveFile(url.toLocalFile());
+
+    // try to open file
+    if (!saveFile.open(QIODevice::WriteOnly)) {
+        qWarning() << "Couldn't open save file:" << uri;
+        return false;
+    }
+
+    // create JSON object
+    QJsonObject saveObject;
+    // write all data
+    writeJson(saveObject);
+    // save to file
+    saveFile.write(QJsonDocument(saveObject).toJson());
+
+    // success
+    return true;
+}
+
 QSharedPointer<Generator> AppModel::getGenerator(int id) const {
     return generatorsHashMap->value(id);
 }
@@ -301,4 +350,14 @@ QSharedPointer<GeneratorModel> AppModel::getGeneratorModel() const {
 QSharedPointer<GeneratorMetaModel> AppModel::getGeneratorMetaModel() const
 {
     return generatorMetaModel;
+}
+
+void AppModel::readJson(const QJsonObject &json)
+{
+    qDebug() << json["test"];
+}
+
+void AppModel::writeJson(QJsonObject &json) const
+{
+    json["test"] = "yo :)";
 }

--- a/autonomx/AppModel.cpp
+++ b/autonomx/AppModel.cpp
@@ -331,8 +331,8 @@ bool AppModel::saveProject(QString uri) {
     // write all data
     writeJson(saveObject);
     // save to file
-    // saveFile.write(QJsonDocument(saveObject).toJson(QJsonDocument::Compact));
-    saveFile.write(QJsonDocument(saveObject).toJson(QJsonDocument::Indented));
+    saveFile.write(QJsonDocument(saveObject).toJson(QJsonDocument::Compact));
+//    saveFile.write(QJsonDocument(saveObject).toJson(QJsonDocument::Indented));
 
     // success
     return true;

--- a/autonomx/AppModel.cpp
+++ b/autonomx/AppModel.cpp
@@ -355,6 +355,7 @@ QSharedPointer<GeneratorMetaModel> AppModel::getGeneratorMetaModel() const
 
 void AppModel::readJson(const QJsonObject &json)
 {
+    // destroy all current generators
     qDebug() << json["version"];
 }
 
@@ -365,7 +366,7 @@ void AppModel::writeJson(QJsonObject &json) const
     json["version"] = QCoreApplication::applicationVersion();
     json["savedAt"] = now;
 
-    // TODO: OSC I/O port numbers + send host
+    // TODO: global OSC I/O port numbers + send host
 
     // write generator data
     QJsonArray generatorData;

--- a/autonomx/AppModel.cpp
+++ b/autonomx/AppModel.cpp
@@ -381,10 +381,8 @@ void AppModel::readJson(const QJsonObject &json)
 
 void AppModel::writeJson(QJsonObject &json) const
 {
-    std::time_t now = std::time(0);
-
     json["version"] = QCoreApplication::applicationVersion();
-    json["savedAt"] = now;
+    json["savedAt"] = QJsonValue::fromVariant(QVariant::fromValue(std::time(0)));
 
     // TODO: global OSC I/O port numbers + send host
 

--- a/autonomx/AppModel.h
+++ b/autonomx/AppModel.h
@@ -46,9 +46,15 @@ public:
     QSharedPointer<GeneratorModel>      getGeneratorModel() const;
     QSharedPointer<GeneratorMetaModel>  getGeneratorMetaModel() const;
 
+    void                readJson(const QJsonObject &json);
+    void                writeJson(QJsonObject &json) const;
+
     Q_INVOKABLE void    createGenerator(QString type);
     Q_INVOKABLE void    deleteGenerator(int id);
     Q_INVOKABLE bool    validateNewGeneratorName(QString name);
+
+    Q_INVOKABLE bool    loadProject(QString uri);
+    Q_INVOKABLE bool    saveProject(QString uri);
 private:
     AppModel();                                 // prevent instanciation
     AppModel(AppModel const&) = delete;         // prevent copy

--- a/autonomx/AppModel.h
+++ b/autonomx/AppModel.h
@@ -46,8 +46,8 @@ public:
     QSharedPointer<GeneratorModel>      getGeneratorModel() const;
     QSharedPointer<GeneratorMetaModel>  getGeneratorMetaModel() const;
 
-    void                                readJson(const QJsonObject &json);
-    void                                writeJson(QJsonObject &json) const;
+    bool                                readJson(const QJsonObject &json);
+    bool                                writeJson(QJsonObject &json) const;
 
     void                                deleteAllGenerators();
 

--- a/autonomx/AppModel.h
+++ b/autonomx/AppModel.h
@@ -46,15 +46,17 @@ public:
     QSharedPointer<GeneratorModel>      getGeneratorModel() const;
     QSharedPointer<GeneratorMetaModel>  getGeneratorMetaModel() const;
 
-    void                readJson(const QJsonObject &json);
-    void                writeJson(QJsonObject &json) const;
+    void                                readJson(const QJsonObject &json);
+    void                                writeJson(QJsonObject &json) const;
 
-    Q_INVOKABLE void    createGenerator(QString type);
-    Q_INVOKABLE void    deleteGenerator(int id);
-    Q_INVOKABLE bool    validateNewGeneratorName(QString name);
+    void                                deleteAllGenerators();
 
-    Q_INVOKABLE bool    loadProject(QString uri);
-    Q_INVOKABLE bool    saveProject(QString uri);
+Q_INVOKABLE QSharedPointer<Generator>   createGenerator(QString type);
+Q_INVOKABLE void                        deleteGenerator(int id);
+Q_INVOKABLE bool                        validateNewGeneratorName(QString name);
+
+Q_INVOKABLE bool                        loadProject(QString uri);
+Q_INVOKABLE bool                        saveProject(QString uri);
 private:
     AppModel();                                 // prevent instanciation
     AppModel(AppModel const&) = delete;         // prevent copy

--- a/autonomx/Generator.cpp
+++ b/autonomx/Generator.cpp
@@ -290,6 +290,16 @@ void Generator::writeLatticeHeight(int latticeHeight) {
     emit latticeHeightChanged(latticeHeight);
 }
 
+void Generator::readJson(const QJsonObject &json)
+{
+
+}
+
+void Generator::writeJson(QJsonObject &json) const
+{
+
+}
+
 void Generator::resetParameters()
 {
     const QMetaObject *metaObject = this->metaObject();

--- a/autonomx/Generator.cpp
+++ b/autonomx/Generator.cpp
@@ -318,6 +318,10 @@ void Generator::writeJson(QJsonObject &json) const
         QString k = target.name();
         QVariant v = target.read(this);
 
+        // typecast enum values
+        if (meta->getEnumLabels().keys().contains(target.typeName()))
+            v = v.toInt();
+
         // write to props obj
         props[k] = QJsonValue::fromVariant(v);
     }

--- a/autonomx/Generator.cpp
+++ b/autonomx/Generator.cpp
@@ -17,6 +17,7 @@
 #include <QThread>
 #include <QTimer>
 #include <QDebug>
+#include <QJsonObject>
 
 #include "Generator.h"
 
@@ -297,7 +298,24 @@ void Generator::readJson(const QJsonObject &json)
 
 void Generator::writeJson(QJsonObject &json) const
 {
+    json["id"] = id;
+    json["type"] = meta->property("type").toString();
+    json["userNotes"] = userNotes;
 
+    // start at oscInputPort
+    const QMetaObject *metaObject = this->metaObject();
+
+    for (int i = metaObject->indexOfProperty("oscInputPort"); i < metaObject->propertyCount(); i++) {
+        // retrieve target QMetaProperty
+        QMetaProperty target = metaObject->property(i);
+
+        // get key and value
+        QString k = target.name();
+        QVariant v = target.read(this);
+
+        // write to JSON object
+        json[k] = QJsonValue::fromVariant(v);
+    }
 }
 
 void Generator::resetParameters()

--- a/autonomx/Generator.h
+++ b/autonomx/Generator.h
@@ -119,6 +119,10 @@ public:
     void writeLatticeWidth(int latticeWidth);
     void writeLatticeHeight(int latticeHeight);
 
+    // serialization methods
+    void readJson(const QJsonObject &json);
+    void writeJson(QJsonObject &json) const;
+
     // these are implemented by the derived class and allow reading / writing to the lattice.
     // this is called by applyInputRegion / applyOutputRegion
     virtual double getLatticeValue(int x, int y) = 0;

--- a/autonomx/GeneratorRegion.cpp
+++ b/autonomx/GeneratorRegion.cpp
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <QQmlEngine>
+#include <QJsonObject>
 
 #include "GeneratorRegion.h"
 
@@ -46,6 +47,20 @@ double GeneratorRegion::getIntensity() const {
 
 int GeneratorRegion::getType() const {
     return type;
+}
+
+void GeneratorRegion::readJson(const QJsonObject &json)
+{
+    // read coords from object and apply
+}
+
+void GeneratorRegion::writeJson(QJsonObject &json) const
+{
+    // write coords to object
+    json["x"] = rect.x();
+    json["y"] = rect.y();
+    json["w"] = rect.width();
+    json["h"] = rect.height();
 }
 
 void GeneratorRegion::writeSilentRect(QRect rect) {

--- a/autonomx/GeneratorRegion.cpp
+++ b/autonomx/GeneratorRegion.cpp
@@ -15,6 +15,7 @@
 
 #include <QQmlEngine>
 #include <QJsonObject>
+#include <QDebug>
 
 #include "GeneratorRegion.h"
 
@@ -51,7 +52,11 @@ int GeneratorRegion::getType() const {
 
 void GeneratorRegion::readJson(const QJsonObject &json)
 {
-    // read coords from object and apply
+    // create new rect from JSON
+    QRect newRect(json["x"].toInt(), json["y"].toInt(), json["w"].toInt(), json["h"].toInt());
+
+    // write to both GeneratorRegionSet and GeneratorRegionModel
+    writeMirroredRect(newRect);
 }
 
 void GeneratorRegion::writeJson(QJsonObject &json) const

--- a/autonomx/GeneratorRegion.h
+++ b/autonomx/GeneratorRegion.h
@@ -21,7 +21,7 @@
 
 class GeneratorRegion : public QObject {
     Q_OBJECT
-    Q_PROPERTY(QRect rect READ getRect WRITE writeSilentRect NOTIFY rectChanged)
+    Q_PROPERTY(QRect rect READ getRect WRITE writeMirroredRect NOTIFY rectChanged)
     Q_PROPERTY(double intensity READ getIntensity WRITE writeSilentIntensity NOTIFY intensityChanged)
     Q_PROPERTY(int type READ getType WRITE writeSilentType NOTIFY typeChanged)
 public:

--- a/autonomx/GeneratorRegion.h
+++ b/autonomx/GeneratorRegion.h
@@ -47,6 +47,9 @@ public:
     double getIntensity() const;
     int getType() const;
 
+    void readJson(const QJsonObject &json);
+    void writeJson(QJsonObject &json) const;
+
     // these are silent writes. they update the value internally and call their linked propertyChanged(value) signals, but don't call valueChanged(key, value). this means this will not update an object that is mirroring it. this is used to carry updates between mirrored objects without causing an infinite update loop.
     // they should not be used directly and are reserved for object mirroring.
     void writeSilentRect(QRect rect);

--- a/autonomx/components/ui/GenericButton.qml
+++ b/autonomx/components/ui/GenericButton.qml
@@ -7,21 +7,26 @@ Button {
     id: genericButton
 
     property color activeColor: Stylesheet.colors.generator
+    property color neutralColor: Stylesheet.colors.darkGrey
+    property color hoverColor: Stylesheet.colors.black
 
-    topPadding: 4
-    bottomPadding: 4
-    leftPadding: 15
-    rightPadding: 15
+    property real paddingSide: 15
+
+    height: 24
+
+    leftPadding: paddingSide
+    rightPadding: paddingSide
 
     contentItem: Label {
         font: Stylesheet.fonts.label
         opacity: hovered ? 1 : 0.75
         text: genericButton.text
+        verticalAlignment: Qt.AlignVCenter
     }
 
     background: Rectangle {
-        anchors.fill: parent
-        color: pressed ? activeColor : (hovered ? Stylesheet.colors.black : Stylesheet.colors.darkGrey)
+        implicitHeight: parent.height
+        color: pressed ? activeColor : (hovered ? hoverColor : neutralColor)
     }
 
     CursorShaper {

--- a/autonomx/components/util/SaveManager.qml
+++ b/autonomx/components/util/SaveManager.qml
@@ -40,8 +40,8 @@ Item {
     FileDialog {
         id: saveDialog
         title: "Save project file as..."
-        nameFilters: ["autonomX save files (*.atnx)"]
-        defaultSuffix: "atnx"
+        nameFilters: ["autonomX save files (*." + extensionName + ")"]
+        defaultSuffix: extensionName
         fileMode: FileDialog.SaveFile
 
         onAccepted: {
@@ -54,8 +54,8 @@ Item {
     FileDialog {
         id: loadDialog
         title: "Load project file..."
-        nameFilters: ["autonomX save files (*.atnx)"]
-        defaultSuffix: "atnx"
+        nameFilters: ["autonomX save files (*." + extensionName + ")"]
+        defaultSuffix: extensionName
         fileMode: FileDialog.OpenFile
 
         onAccepted: {

--- a/autonomx/components/util/SaveManager.qml
+++ b/autonomx/components/util/SaveManager.qml
@@ -1,0 +1,69 @@
+import QtQuick 2.9
+import Qt.labs.platform 1.0
+
+Item {
+    id: saveManager
+
+    property string currentFileUri
+    property string currentFileName: basename(currentFileUri)
+
+    function basename(str) {
+        return (str.slice(str.lastIndexOf("/")+1));
+    }
+
+    function load() {
+        loadDialog.open()
+    }
+
+    function save() {
+        if (!currentFileUri) saveDialog.open()
+        else {
+            if (appModel.saveProject(currentFileUri)) {
+                // TODO: successful save animation :)
+            }
+        }
+    }
+
+    function saveAs() {
+        saveDialog.open()
+    }
+
+    // changes lost warning
+    MessageDialog {
+        text: "You are about to modify the current project. Any unsaved changes will be lost."
+        informativeText: "Do you want to continue?"
+
+        buttons: MessageDialog.Ok | MessageDialog.Cancel
+    }
+
+    // save dialog
+    FileDialog {
+        id: saveDialog
+        title: "Save project file as..."
+        nameFilters: ["autonomX save files (*.atnx)"]
+        defaultSuffix: "atnx"
+        fileMode: FileDialog.SaveFile
+
+        onAccepted: {
+            currentFileUri = currentFile
+            appModel.saveProject(currentFileUri)
+        }
+    }
+
+    // load dialog
+    FileDialog {
+        id: loadDialog
+        title: "Load project file..."
+        nameFilters: ["autonomX save files (*.atnx)"]
+        defaultSuffix: "atnx"
+        fileMode: FileDialog.OpenFile
+
+        onAccepted: {
+            currentFileUri = currentFile
+
+            if (appModel.loadProject(currentFileUri)) {
+                activeGeneratorIndex = -1;
+            }
+        }
+    }
+}

--- a/autonomx/layout/Header.qml
+++ b/autonomx/layout/Header.qml
@@ -1,17 +1,11 @@
 import QtQuick 2.11
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.3
-import Qt.labs.platform 1.0
 
 import "qrc:/stylesheet"
 import "../components/ui"
 
 ColumnLayout {
-    property string currentFileUri
-
-    function basename(str) {
-        return (str.slice(str.lastIndexOf("/")+1));
-    }
 
     Layout.fillWidth: true
     spacing: 0
@@ -25,45 +19,6 @@ ColumnLayout {
         Layout.preferredHeight: 30
 
         color: Stylesheet.colors.black
-
-        // changes lost warning
-        MessageDialog {
-            text: "You are about to modify the current project. Any unsaved changes will be lost."
-            informativeText: "Do you want to continue?"
-
-            buttons: MessageDialog.Ok | MessageDialog.Cancel
-        }
-
-        // save dialog
-        FileDialog {
-            id: saveDialog
-            title: "Save project file as..."
-            nameFilters: ["autonomX save files (*.atnx)"]
-            defaultSuffix: "atnx"
-            fileMode: FileDialog.SaveFile
-
-            onAccepted: {
-                currentFileUri = currentFile
-                appModel.saveProject(currentFileUri)
-            }
-        }
-
-        // load dialog
-        FileDialog {
-            id: loadDialog
-            title: "Load project file..."
-            nameFilters: ["autonomX save files (*.atnx)"]
-            defaultSuffix: "atnx"
-            fileMode: FileDialog.OpenFile
-
-            onAccepted: {
-                currentFileUri = currentFile
-
-                if (appModel.loadProject(currentFileUri)) {
-                    activeGeneratorIndex = -1;
-                }
-            }
-        }
 
         RowLayout {
             anchors.fill: parent
@@ -82,7 +37,7 @@ ColumnLayout {
                 Layout.alignment: Qt.AlignLeft
                 Layout.fillHeight: true
 
-                onClicked: loadDialog.open()
+                onClicked: saveManager.load()
             }
 
             GenericButton {
@@ -91,14 +46,7 @@ ColumnLayout {
                 Layout.alignment: Qt.AlignLeft
                 Layout.fillHeight: true
 
-                onClicked: {
-                    if (!currentFileUri) saveDialog.open()
-                    else {
-                        if (appModel.saveProject(currentFileUri)) {
-                            // TODO: successful save animation :)
-                        }
-                    }
-                }
+                onClicked: saveManager.save()
             }
 
             GenericButton {
@@ -107,7 +55,7 @@ ColumnLayout {
                 Layout.alignment: Qt.AlignLeft
                 Layout.fillHeight: true
 
-                onClicked: saveDialog.open()
+                onClicked: saveManager.saveAs()
             }
 
             Item {
@@ -120,8 +68,8 @@ ColumnLayout {
             horizontalAlignment: Qt.AlignHCenter
             verticalAlignment: Qt.AlignVCenter
 
-            text: currentFileUri ? basename(currentFileUri) : '<no project loaded>'
-            opacity: currentFileUri ? 1 : 0.5
+            text: currentFileName ? currentFileName : '<no project loaded>'
+            opacity: currentFileName ? 1 : 0.5
             font: Stylesheet.fonts.text
         }
     }

--- a/autonomx/layout/Header.qml
+++ b/autonomx/layout/Header.qml
@@ -9,6 +9,10 @@ import "../components/ui"
 ColumnLayout {
     property string currentFileUri
 
+    function basename(str) {
+        return (str.slice(str.lastIndexOf("/")+1));
+    }
+
     Layout.fillWidth: true
     spacing: 0
     z: 100
@@ -88,7 +92,11 @@ ColumnLayout {
 
                 onClicked: {
                     if (!currentFileUri) saveDialog.open()
-                    else appModel.saveProject(currentFileUri)
+                    else {
+                        if (appModel.saveProject(currentFileUri)) {
+                            // TODO: successful save animation :)
+                        }
+                    }
                 }
             }
 
@@ -104,6 +112,16 @@ ColumnLayout {
             Item {
                 Layout.fillWidth: true
             }
+        }
+
+        Label {
+            anchors.fill: parent
+            horizontalAlignment: Qt.AlignHCenter
+            verticalAlignment: Qt.AlignVCenter
+
+            text: currentFileUri ? basename(currentFileUri) : '<no project loaded>'
+            opacity: currentFileUri ? 1 : 0.5
+            font: Stylesheet.fonts.text
         }
     }
 

--- a/autonomx/layout/Header.qml
+++ b/autonomx/layout/Header.qml
@@ -54,7 +54,10 @@ ColumnLayout {
 
             onAccepted: {
                 currentFileUri = currentFile
-                appModel.loadProject(currentFileUri)
+
+                if (appModel.loadProject(currentFileUri)) {
+                    activeGeneratorIndex = -1;
+                }
             }
         }
 

--- a/autonomx/layout/Header.qml
+++ b/autonomx/layout/Header.qml
@@ -68,12 +68,13 @@ ColumnLayout {
         RowLayout {
             anchors.fill: parent
 
-            GenericButton {
-                neutralColor: Stylesheet.colors.black
-                text: "New"
-                Layout.alignment: Qt.AlignLeft
-                Layout.fillHeight: true
-            }
+            // TODO: the C++ function for this button
+//            GenericButton {
+//                neutralColor: Stylesheet.colors.black
+//                text: "New"
+//                Layout.alignment: Qt.AlignLeft
+//                Layout.fillHeight: true
+//            }
 
             GenericButton {
                 neutralColor: Stylesheet.colors.black

--- a/autonomx/layout/Header.qml
+++ b/autonomx/layout/Header.qml
@@ -11,6 +11,7 @@ ColumnLayout {
 
     Layout.fillWidth: true
     spacing: 0
+    z: 100
 
     // save/load bar
     Rectangle {
@@ -18,7 +19,6 @@ ColumnLayout {
 
         Layout.fillWidth: true
         Layout.preferredHeight: 30
-        z: 100
 
         color: Stylesheet.colors.black
 
@@ -110,7 +110,6 @@ ColumnLayout {
 
         Layout.fillWidth: true
         Layout.preferredHeight: Stylesheet.headerHeight
-        z: 100
 
         Rectangle {
             anchors.fill: parent
@@ -207,3 +206,4 @@ ColumnLayout {
             }
         }
     }
+}

--- a/autonomx/main.cpp
+++ b/autonomx/main.cpp
@@ -52,6 +52,7 @@ int main(int argc, char *argv[]) {
 
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication app(argc, argv);
+
     // global settings
     QCoreApplication::setApplicationName("autonomX");
     QCoreApplication::setApplicationVersion("0.1.1");

--- a/autonomx/main.cpp
+++ b/autonomx/main.cpp
@@ -51,8 +51,11 @@ int main(int argc, char *argv[]) {
     #endif
 
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-
     QGuiApplication app(argc, argv);
+    // global settings
+    QCoreApplication::setApplicationName("autonomX");
+    QCoreApplication::setApplicationVersion("0.1.1");
+    QCoreApplication::setOrganizationName("Xmodal");
 
 
     // load fonts in the project database
@@ -62,9 +65,9 @@ int main(int argc, char *argv[]) {
             qDebug() << "Failed to load font " << file;
     }
 
+
     qDebug() << "Built against Qt" << QT_VERSION_STR;
     qDebug() << "Using Qt" << QLibraryInfo::version() << "at runtime";
-
     qDebug() << "GUI id = " << QThread::currentThreadId();
 
 

--- a/autonomx/main.cpp
+++ b/autonomx/main.cpp
@@ -53,10 +53,16 @@ int main(int argc, char *argv[]) {
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication app(argc, argv);
 
+    // constant settings
+    const char* applicationName = "autonomX";
+    const char* applicationVersion = "0.1.1";
+    const char* organizationName = "Xmodal";
+    const char* extensionName = "atnx";
+
     // global settings
-    QCoreApplication::setApplicationName("autonomX");
-    QCoreApplication::setApplicationVersion("0.1.1");
-    QCoreApplication::setOrganizationName("Xmodal");
+    QCoreApplication::setApplicationName(applicationName);
+    QCoreApplication::setApplicationVersion(applicationVersion);
+    QCoreApplication::setOrganizationName(organizationName);
 
 
     // load fonts in the project database
@@ -104,6 +110,7 @@ int main(int argc, char *argv[]) {
     qmlEngine.rootContext()->setContextProperty("appModel", &AppModel::getInstance());
     qmlEngine.rootContext()->setContextProperty("generatorModel", AppModel::getInstance().getGeneratorModel().data());
     qmlEngine.rootContext()->setContextProperty("generatorMetaModel", AppModel::getInstance().getGeneratorMetaModel().data());
+    qmlEngine.rootContext()->setContextProperty("extensionName", extensionName);
     qmlEngine.load(QUrl(QStringLiteral("qrc:/main.qml")));
     if (qmlEngine.rootObjects().isEmpty())
         return -1;

--- a/autonomx/main.qml
+++ b/autonomx/main.qml
@@ -103,7 +103,7 @@ ApplicationWindow {
         onActivated: toggleFullscreen()
     }
     Shortcut {
-        sequence: "Ctrl+Q"
+        sequence: [StandardKey.Quit, "Ctrl+Q"]
         onActivated: quitThisApp()
     }
     Shortcut {
@@ -127,33 +127,33 @@ ApplicationWindow {
     // serialization
     Shortcut {
         id: saveSC
-        sequence: "Ctrl+S"
+        sequence: [StandardKey.Save, "Ctrl+S"]
 
         onActivated: saveManager.save()
     }
     Shortcut {
         id: saveAsSC
-        sequence: "Ctrl+Shift+S"
+        sequence: [StandardKey.SaveAs, "Ctrl+Shift+S"]
 
         onActivated: saveManager.saveAs()
     }
     Shortcut {
         id: loadSC
-        sequence: "Ctrl+L"
+        sequence: [StandardKey.Open, "Ctrl+O", "Ctrl+L"]
 
         onActivated: saveManager.load()
     }
     Shortcut {
         id: newSC
-        sequence: "Ctrl+N"
+        sequence: [StandardKey.New, "Ctrl+N"]
     }
     Shortcut {
         id: undoSC
-        sequence: "Ctrl+Z"
+        sequence: [StandardKey.Undo, "Ctrl+Z"]
     }
     Shortcut {
         id: redoSC
-        sequence: "Ctrl+Y"
+        sequence: [StandardKey.Redo, "Ctrl+Y", "Ctrl+Shift+Z"]
     }
 
     // main content

--- a/autonomx/main.qml
+++ b/autonomx/main.qml
@@ -23,9 +23,11 @@ ApplicationWindow {
         metaModel = generatorMetaModel.at(generatorModel.at(activeGeneratorIndex).type)
     }
 
+    // UI switch flags
     property bool showGeneratorList: true
     property bool showGeneratorSettings: true
 
+    // global field helper flags
     property bool altPressed: false
     property bool shiftPressed: false
     property bool editingTextField: false
@@ -114,6 +116,32 @@ ApplicationWindow {
             if (i >= generatorModel.rowCount()) i--;
             activeGeneratorIndex = i;
         }
+    }
+
+    // serialization
+    Shortcut {
+        id: saveSC
+        sequence: "Ctrl+S"
+    }
+    Shortcut {
+        id: saveAsSC
+        sequence: "Ctrl+Alt+S"
+    }
+    Shortcut {
+        id: loadSC
+        sequence: "Ctrl+L"
+    }
+    Shortcut {
+        id: newSC
+        sequence: "Ctrl+N"
+    }
+    Shortcut {
+        id: undoSC
+        sequence: "Ctrl+Z"
+    }
+    Shortcut {
+        id: redoSC
+        sequence: "Ctrl+Y"
     }
 
     // main content

--- a/autonomx/main.qml
+++ b/autonomx/main.qml
@@ -128,14 +128,20 @@ ApplicationWindow {
     Shortcut {
         id: saveSC
         sequence: "Ctrl+S"
+
+        onActivated: saveManager.save()
     }
     Shortcut {
         id: saveAsSC
         sequence: "Ctrl+Alt+S"
+
+        onActivated: saveManager.saveAs()
     }
     Shortcut {
         id: loadSC
         sequence: "Ctrl+L"
+
+        onActivated: saveManager.load()
     }
     Shortcut {
         id: newSC

--- a/autonomx/main.qml
+++ b/autonomx/main.qml
@@ -133,7 +133,7 @@ ApplicationWindow {
     }
     Shortcut {
         id: saveAsSC
-        sequence: "Ctrl+Alt+S"
+        sequence: "Ctrl+Shift+S"
 
         onActivated: saveManager.saveAs()
     }

--- a/autonomx/main.qml
+++ b/autonomx/main.qml
@@ -103,7 +103,7 @@ ApplicationWindow {
         onActivated: toggleFullscreen()
     }
     Shortcut {
-        sequence: [StandardKey.Quit, "Ctrl+Q"]
+        sequences: [StandardKey.Quit, "Ctrl+Q"]
         onActivated: quitThisApp()
     }
     Shortcut {
@@ -127,33 +127,39 @@ ApplicationWindow {
     // serialization
     Shortcut {
         id: saveSC
-        sequence: [StandardKey.Save, "Ctrl+S"]
+        sequences: [StandardKey.Save]
 
         onActivated: saveManager.save()
     }
     Shortcut {
         id: saveAsSC
-        sequence: [StandardKey.SaveAs, "Ctrl+Shift+S"]
+        sequences: [StandardKey.SaveAs, "Ctrl+Shift+S"]
 
         onActivated: saveManager.saveAs()
     }
     Shortcut {
         id: loadSC
-        sequence: [StandardKey.Open, "Ctrl+O", "Ctrl+L"]
+        sequences: [StandardKey.Open, "Ctrl+L"]
 
         onActivated: saveManager.load()
     }
     Shortcut {
         id: newSC
-        sequence: [StandardKey.New, "Ctrl+N"]
+        sequences: [StandardKey.New]
+
+        onActivated: console.log("new")
     }
     Shortcut {
         id: undoSC
-        sequence: [StandardKey.Undo, "Ctrl+Z"]
+        sequences: [StandardKey.Undo]
+
+        onActivated: console.log("undo");
     }
     Shortcut {
         id: redoSC
-        sequence: [StandardKey.Redo, "Ctrl+Y", "Ctrl+Shift+Z"]
+        sequences: [StandardKey.Redo, "Ctrl+Shift+Z"]
+
+        onActivated: console.log("redo");
     }
 
     // main content

--- a/autonomx/main.qml
+++ b/autonomx/main.qml
@@ -26,10 +26,6 @@ ApplicationWindow {
     property bool showGeneratorList: true
     property bool showGeneratorSettings: true
 
-    // We update this version number each time we do a release/tag.
-    // We follow Semantic Versioning 2.0.0 https://semver.org/
-    readonly property string softwareVersion: "0.1.1-SNAPSHOT"
-
     property bool altPressed: false
     property bool shiftPressed: false
     property bool editingTextField: false
@@ -42,7 +38,7 @@ ApplicationWindow {
     visible: true
     width: 1440
     height: 720
-    title: qsTr("autonomX") + " " + softwareVersion
+    title: Qt.application.name + " " + Qt.application.version
 
     function toggleFullscreen() {
         if (visibility === Window.FullScreen) {

--- a/autonomx/main.qml
+++ b/autonomx/main.qml
@@ -5,6 +5,7 @@ import QtQuick.Window 2.11
 
 import "./stylesheet"
 import "./layout"
+import "./components/util"
 
 /**
  * Main window of this application
@@ -33,6 +34,11 @@ ApplicationWindow {
     property bool editingTextField: false
     property alias allowSlideDrag: slideDragger.visible
 
+    // saving stuff
+    property alias saveManager: saveManager
+    property alias currentFileName: saveManager.currentFileName
+
+    // changes when
     onEditingTextFieldChanged: {
         if (editingTextField) deAlt(mainContent)
     }
@@ -215,5 +221,9 @@ ApplicationWindow {
                 parent.y = 0
             }
         }
+    }
+
+    SaveManager {
+        id: saveManager
     }
 }

--- a/autonomx/qml.qrc
+++ b/autonomx/qml.qrc
@@ -52,5 +52,6 @@
         <file>shaders/slider_frame.frag</file>
         <file>stylesheet/qmldir</file>
         <file>stylesheet/Stylesheet.qml</file>
+        <file>components/util/SaveManager.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
closes #238; closes #239; closes #227; closes #245; closes #241; closes #240

a system for writing to and reading from JSON save files has been implemented in AppModel, as well as corresponding methods in Generator and GeneratorRegion to respectively retrieve outgoing data and apply incoming data.

specifically, key functions were added in `AppModel`: `loadProject`, `saveProject`, `readJson` and `writeJson`. the former two take care of file system R/W operations exclusively, and then call their associated JSON function which, in turn, will be responsible for either reading the app's data or overwriting it. those two latter methods, on top of managing global JSON properties, will call their associated implementation for every concerned Generator instance; and, for each of those, the same process is applied for every GeneratorRegion instance. these methods' naming convention has been made consistent to facilitate code reading.

most of the code here has been directly borrowed from [this Qt tutorial on serialization](https://doc.qt.io/qt-5/qtcore-serialization-savegame-example.html).

a supplementary header bar dedicated to serialization actions has also been added in the GUI, with three buttons ("Load", "Save" and "Save as") that take care of dialog display and AppModel method invoking. in addition, keyboard shortcuts have been mapped to these three operations; respectively "Ctrl+L", "Ctrl+S" and "Ctrl+Shift+S".

PLEASE NOTE: **loading a project will sometimes crash!** this is a known bug which has been investigated and already properly fixed. it will be uploaded as its separate PR because of feature disparity w/ `dynamic-generators-integration`.