### PR TITLE
fix crash-inducing interface display bugs

### DIFF
--- a/autonomx/components/racks/ParametersRack.qml
+++ b/autonomx/components/racks/ParametersRack.qml
@@ -32,9 +32,7 @@ ColumnLayout {
                 // destroy previous fields
                 destroyGUI();
 
-                // reset fields
-                paramsSubRack.fields = [];
-
+                // define props
                 let fieldData = metaModel.fieldTree[modelData];
                 let fields = [];
 
@@ -81,16 +79,17 @@ ColumnLayout {
                     let fieldObj = componentToCreate.createObject(null, props);
 
                     // push to field array
-                    paramsSubRack.fields.push(fieldObj)
+                    fields.push(fieldObj)
                 }
+
+                paramsSubRack.fields = fields;
             }
 
             function destroyGUI() {
                 for (let i = 0; i < paramsSubRack.fields.length; i++) {
-                    if (!paramsSubRack.fields[i]) continue;
-
-                    paramsSubRack.fields[i].reset();
-                    paramsSubRack.fields[i].destroy();
+                    if (!this.fields[i]) continue;
+                    this.fields[i].reset();
+                    this.fields[i].destroy();
                 }
             }
         }

--- a/autonomx/components/ui/Region.qml
+++ b/autonomx/components/ui/Region.qml
@@ -35,6 +35,12 @@ Rectangle {
 
         area = rect.width * rect.height;
         area = area;
+
+        // assign connections once region is created
+        // (for some reason, having them initialized pre-completion
+        // causes uninvoked snapping when going from a generator to another)
+        region.latticeWidthChanged.connect(function() { region.snapToGrid("drag") } )
+        region.latticeHeightChanged.connect(function() { region.snapToGrid("drag") } )
     }
 
     // matrix.setMask() update slots
@@ -42,10 +48,6 @@ Rectangle {
     onYChanged: updateBounds()
     onWidthChanged: updateBounds()
     onHeightChanged: updateBounds()
-
-    // reposition region if out of bounds
-    onLatticeWidthChanged: snapToGrid("drag")
-    onLatticeHeightChanged: snapToGrid("drag")
 
     // animation triggers
     NumberAnimation on x { id: snapX; running: false; duration: 250; easing.type: Easing.OutCirc; }


### PR DESCRIPTION
fixes a series of interconnected bugs relating to the proper display of exposed Qt properties in the GUI. elements affected were namely the lattice regions, which would snap sparsely to the grid, and parameter fields, some of which would sometimes not show up at all. these fixes also (somehow) solve two edge cases for app crashes.