### PR TITLE
Input Region Bug Fix

### DIFF
--- a/autonomx/ComputeEngine.cpp
+++ b/autonomx/ComputeEngine.cpp
@@ -71,6 +71,9 @@ void ComputeEngine::receiveOscData(int id, QVariantList data) {
         generator->getInputRegionSet()->getRegion(i)->writeMirroredIntensity(input);
     }
 
+    // alerts loop that new value was received via inputOSC and can be reflected in lattice
+    inputValueReceived = true;
+
     if(flagDebug) {
         std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
                     std::chrono::system_clock::now().time_since_epoch()
@@ -135,9 +138,15 @@ void ComputeEngine::loop() {
     elapsedTimer.restart();
     elapsedTimer.start();
 
-    // apply input values
-    for(QList<QSharedPointer<Generator>>::iterator it = generatorsList->begin(); it != generatorsList->end(); it++) {
-        (*it)->applyInputRegion();
+    // check if input value received via OSC this loop
+    if(inputValueReceived) {
+        // apply input values
+        for(QList<QSharedPointer<Generator>>::iterator it = generatorsList->begin(); it != generatorsList->end(); it++) {
+            (*it)->applyInputRegion();
+        }
+
+        // reset check to prevent values being erased on every loop
+        inputValueReceived = false;
     }
 
     // do the computation

--- a/autonomx/ComputeEngine.h
+++ b/autonomx/ComputeEngine.h
@@ -34,6 +34,7 @@ private:
     QElapsedTimer elapsedTimer;
     double frequency = 60;
     bool firstFrame = true;
+    bool inputValueReceived = false;
     bool flagDebug = false;
     bool flagDummyOutputMonitor = false;
     bool flagDummyOscOutput = false;

--- a/autonomx/WolframCA.cpp
+++ b/autonomx/WolframCA.cpp
@@ -122,7 +122,7 @@ void WolframCA::computeIteration(double deltaTime) {
         generate(r);
     }
 
-    // every 1000 iterations, currentGeneration increments and iterationNumber resets
+    // every 50 iterations, currentGeneration increments and iterationNumber resets
     if(iterationNumber % 50 == 0) {
         currentGeneration++;
         iterationNumber = 1;

--- a/autonomx/main.cpp
+++ b/autonomx/main.cpp
@@ -96,9 +96,8 @@ int main(int argc, char *argv[]) {
     qmlRegisterUncreatableMetaObject(NeuronTypeNS::staticMetaObject, "ca.hexagram.xmodal.autonomx", 1, 0, "NeuronType", "Cannot instanciate NeuronType.");
 
 
-    // create initial generators
+    // create initial generator
     AppModel::getInstance().createGenerator("SpikingNet");
-    // AppModel::getInstance().createGenerator("WolframCA");
 
     QQmlApplicationEngine qmlEngine;
 


### PR DESCRIPTION
Bug is now fixed for all generators.
However, worth noting that any values received via OSC input port to WolframCA lattice will cause those regions to erase (again). This is not a bug though - WolframCA simply hasn't implemented a way to handle input messages, yet.