### PR TITLE
raise default lattice size; globalize general params sub-rack

### DIFF
--- a/autonomx/GameOfLife.cpp
+++ b/autonomx/GameOfLife.cpp
@@ -15,6 +15,7 @@ GameOfLife::GameOfLife(int id, GeneratorMeta * meta) : Generator(id, meta)
         qDebug() << "constructor (WolframCA):\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
     }
 
+    timeScale = 95;
     initialize();
 }
 
@@ -140,11 +141,8 @@ void GameOfLife::computeIteration(double deltaTime)
 {
     temp_cells = cells;
 
-    //get the time scale
-    int timeScale = getTimeScale();
-
     // compute iteration here
-    if (iterationNumber % (100 - timeScale + 1) == 0) {
+    if (iterationNumber % (100 - (int)(timeScale) + 1) == 0) {
         for (int i = 1; i < latticeHeight - 1; i++) {
             for (int j = 1; j < latticeWidth - 1; j++) {
 
@@ -218,28 +216,6 @@ void GameOfLife::writeLatticeValue(int x, int y, double value)
     // write values to lattice
     int index = x % latticeWidth + y * latticeWidth;
     cells[index] = value;
-}
-
-double GameOfLife::getTimeScale() const {
-    return this->timeScale;
-}
-
-
-void GameOfLife::writeTimeScale(double timeScale) {
-    if(this->timeScale == timeScale)
-        return;
-
-    if(flagDebug) {
-        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                    std::chrono::system_clock::now().time_since_epoch()
-        );
-
-        qDebug() << "writeTimeScale:\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
-    }
-
-    this->timeScale = timeScale;
-    emit valueChanged("timeScale", QVariant(timeScale));
-    emit timeScaleChanged(timeScale);
 }
 
 int GameOfLife::getRule()

--- a/autonomx/GameOfLife.h
+++ b/autonomx/GameOfLife.h
@@ -22,7 +22,6 @@ class GameOfLife : public Generator
 {
     Q_OBJECT
 
-    Q_PROPERTY(int timeScale READ getTimeScale WRITE writeTimeScale NOTIFY timeScaleChanged)
     Q_PROPERTY(int rule READ getRule WRITE writeRule NOTIFY ruleChanged)
     Q_PROPERTY(GOLPatternType GOLPattern READ getGOLPattern WRITE writeGOLPattern NOTIFY GOLPatternChanged)
 
@@ -37,9 +36,6 @@ private:
 
     // properties and rules
     int rule = 102;
-
-    //time scale to manipulate the speed of the iterations
-    int timeScale = 95;
 
     //pattern name
     GOLPatternType GOLPattern = GOLPatternType::Random;
@@ -69,14 +65,11 @@ public:
     // prop hooks
     int getRule();
     void writeRule(int rule);
-    void writeTimeScale(double timeScale);
-    double getTimeScale() const;
     GOLPatternType getGOLPattern() const;
     void writeGOLPattern(GOLPatternType GOLPattern);
 
 signals:
     // QML signals
-    void timeScaleChanged(double timeScale);
     void randSeedChanged(double randSeed);
     void ruleChanged(int rule);
     void GOLPatternChanged(GOLPatternType GOLPattern);

--- a/autonomx/Generator.cpp
+++ b/autonomx/Generator.cpp
@@ -142,6 +142,11 @@ int Generator::getLatticeHeight() {
     return latticeHeight;
 }
 
+double Generator::getTimeScale() const
+{
+    return timeScale;
+}
+
 void Generator::writeGeneratorName(QString generatorName) {
     if (this->generatorName == generatorName)
         return;
@@ -353,6 +358,19 @@ void Generator::writeLatticeHeight(int latticeHeight) {
     emit latticeHeightChanged(latticeHeight);
 }
 
+void Generator::writeTimeScale(double timeScale)
+{
+    if (this->timeScale == timeScale) {
+        return;
+    }
+
+    // update property locally
+    this->timeScale = timeScale;
+
+    emit valueChanged("timeScale", timeScale);
+    emit timeScaleChanged(timeScale);
+}
+
 void Generator::readJson(const QJsonObject &json)
 {
     // 000. GENERAL DATA
@@ -477,15 +495,11 @@ void Generator::resetRegions()
 {
     // input rectangles reset
     inputRegionSet->deleteAllRegions();
-    for(int i = 0; i < 4; i++) {
-        inputRegionSet->addRegion(1+(i*5), 3, 3, 3);
-    }
+    inputRegionSet->initialize();
 
-   // output rectangles reset
-   outputRegionSet->deleteAllRegions();
-   for(int i = 0; i < 4; i++) {
-       outputRegionSet->addRegion(1+(i*5), 14, 3, 3);
-   }
+    // output rectangles reset
+    outputRegionSet->deleteAllRegions();
+    outputRegionSet->initialize();
 }
 
 void Generator::initializeRegionSets()

--- a/autonomx/Generator.h
+++ b/autonomx/Generator.h
@@ -55,6 +55,7 @@ class Generator : public QObject {
 
     Q_PROPERTY(int latticeWidth READ getLatticeWidth WRITE writeLatticeWidth NOTIFY latticeWidthChanged)
     Q_PROPERTY(int latticeHeight READ getLatticeHeight WRITE writeLatticeHeight NOTIFY latticeHeightChanged)
+    Q_PROPERTY(double timeScale READ getTimeScale WRITE writeTimeScale NOTIFY timeScaleChanged)
 public:
     // enum used by GeneratorModel
     // essentially, these are the properties we want to have ready
@@ -118,6 +119,7 @@ public:
 
     int getLatticeWidth();
     int getLatticeHeight();
+    double getTimeScale() const;
 
     // methods to write properties
     void writeGeneratorName(QString generatorName);
@@ -135,6 +137,7 @@ public:
     // these only take care of doing the signaling
     void writeLatticeWidth(int latticeWidth);
     void writeLatticeHeight(int latticeHeight);
+    void writeTimeScale(double timeScale);
 
     // serialization methods
     void readJson(const QJsonObject &json);
@@ -160,8 +163,9 @@ public:
     GeneratorRegionSet* getInputRegionSet();
     GeneratorRegionSet* getOutputRegionSet();
 protected:
-    int latticeWidth = 20;                      // lattice width
-    int latticeHeight = 20;                     // lattice height
+    int latticeWidth = 50;                      // lattice width
+    int latticeHeight = 50;                     // lattice height
+    double timeScale = 100;
 private:
     int id;                                     // generator id, generated automatically by ComputeEngine in constructor
 
@@ -243,6 +247,7 @@ signals:
 
     void latticeWidthChanged(int latticeWidth);
     void latticeHeightChanged(int latticeHeight);
+    void timeScaleChanged(double timeScale);
 
     // tells the GeneratorLatticeCommunicator that the previously created writeLatticeData request is completed, and that a new one can be started at the end of the current render frame.
     //

--- a/autonomx/GeneratorRegionSet.cpp
+++ b/autonomx/GeneratorRegionSet.cpp
@@ -50,19 +50,19 @@ void GeneratorRegionSet::initialize()
 
 void GeneratorRegionSet::initializeAsInput() {
     // optimized for 20x20 lattice size
-    regionList.append((QSharedPointer<GeneratorRegion>) new GeneratorRegion(QRect(1, 3, 3, 3), 0.0, 0));
-    regionList.append((QSharedPointer<GeneratorRegion>) new GeneratorRegion(QRect(6, 3, 3, 3), 0.0, 0));
-    regionList.append((QSharedPointer<GeneratorRegion>) new GeneratorRegion(QRect(11, 3, 3, 3), 0.0, 0));
-    regionList.append((QSharedPointer<GeneratorRegion>) new GeneratorRegion(QRect(16, 3, 3, 3), 0.0, 0));
+    regionList.append((QSharedPointer<GeneratorRegion>) new GeneratorRegion(QRect(3, 7, 8, 8), 0.0, 0));
+    regionList.append((QSharedPointer<GeneratorRegion>) new GeneratorRegion(QRect(15, 7, 8, 8), 0.0, 0));
+    regionList.append((QSharedPointer<GeneratorRegion>) new GeneratorRegion(QRect(27, 7, 8, 8), 0.0, 0));
+    regionList.append((QSharedPointer<GeneratorRegion>) new GeneratorRegion(QRect(39, 7, 8, 8), 0.0, 0));
     createConnections();
 }
 
 void GeneratorRegionSet::initializeAsOutput() {
     // optimized for 20x20 lattice size
-    regionList.append((QSharedPointer<GeneratorRegion>) new GeneratorRegion(QRect(1, 14, 3, 3), 0.0, 1));
-    regionList.append((QSharedPointer<GeneratorRegion>) new GeneratorRegion(QRect(6, 14, 3, 3), 0.0, 1));
-    regionList.append((QSharedPointer<GeneratorRegion>) new GeneratorRegion(QRect(11, 14, 3, 3), 0.0, 1));
-    regionList.append((QSharedPointer<GeneratorRegion>) new GeneratorRegion(QRect(16, 14, 3, 3), 0.0, 1));
+    regionList.append((QSharedPointer<GeneratorRegion>) new GeneratorRegion(QRect(3, 35, 8, 8), 0.0, 1));
+    regionList.append((QSharedPointer<GeneratorRegion>) new GeneratorRegion(QRect(15, 35, 8, 8), 0.0, 1));
+    regionList.append((QSharedPointer<GeneratorRegion>) new GeneratorRegion(QRect(27, 35, 8, 8), 0.0, 1));
+    regionList.append((QSharedPointer<GeneratorRegion>) new GeneratorRegion(QRect(39, 35, 8, 8), 0.0, 1));
     createConnections();
 }
 

--- a/autonomx/SpikingNet.cpp
+++ b/autonomx/SpikingNet.cpp
@@ -298,7 +298,7 @@ void SpikingNet::computeIteration(double deltaTime) {
     }
 
     // apply time scale
-    deltaTime *= timeScale;
+    deltaTime *= timeScale / 100.0 * 30.0 / 1000.0;
 
     // update routine
     if(flagDecay) applyDecay(deltaTime);
@@ -524,10 +524,6 @@ void SpikingNet::applyDecay(double deltaTime) {
 
 // ############################### Qt read / write ###############################
 
-double SpikingNet::getTimeScale() const {
-    return this->timeScale;
-}
-
 double SpikingNet::getInhibitoryPortion() const {
     return this->inhibitoryPortion;
 }
@@ -570,23 +566,6 @@ bool SpikingNet::getFlagSTDP() const {
 
 bool SpikingNet::getFlagDecay() const {
     return this->flagDecay;
-}
-
-void SpikingNet::writeTimeScale(double timeScale) {
-    if(this->timeScale == timeScale)
-        return;
-
-    if(flagDebug) {
-        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                    std::chrono::system_clock::now().time_since_epoch()
-        );
-
-        qDebug() << "writeTimeScale:\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
-    }
-
-    this->timeScale = timeScale;
-    emit valueChanged("timeScale", QVariant(timeScale));
-    emit timeScaleChanged(timeScale);
 }
 
 void SpikingNet::writeInhibitoryPortion(double inhibitoryPortion) {

--- a/autonomx/SpikingNet.h
+++ b/autonomx/SpikingNet.h
@@ -25,8 +25,6 @@
 class SpikingNet : public Generator {
     // TODO: figure out how we decide to add / remove inputs. this should probably be a property that belongs to the Generator abstract class, rather than this.
     Q_OBJECT
-    Q_PROPERTY(double timeScale READ getTimeScale WRITE writeTimeScale NOTIFY timeScaleChanged)
-
     Q_PROPERTY(double inhibitoryPortion READ getInhibitoryPortion WRITE writeInhibitoryPortion NOTIFY inhibitoryPortionChanged)
     Q_PROPERTY(NeuronType inhibitoryNeuronType READ getInhibitoryNeuronType WRITE writeInhibitoryNeuronType NOTIFY inhibitoryNeuronTypeChanged)
     Q_PROPERTY(NeuronType excitatoryNeuronType READ getExcitatoryNeuronType WRITE writeExcitatoryNeuronType NOTIFY excitatoryNeuronTypeChanged)
@@ -73,7 +71,7 @@ private:
     double      decayHalfLife = 10.0;
     double      decayConstant = std::pow(2.0, - 1.0 / decayHalfLife);
 
-    double      timeScale = 30.0 / 1000.0;
+    // double      timeScale = 30.0 / 1000.0;
 
     double STDPStrength = 1.0;
     double STPStrength = 1.0;
@@ -129,7 +127,6 @@ public:
     void writeLatticeValue(int x, int y, double value) override;
 
     int getNeuronSize() const;
-    double getTimeScale() const;
     double getInhibitoryPortion() const;
     NeuronType getInhibitoryNeuronType() const;
     NeuronType getExcitatoryNeuronType() const;
@@ -143,7 +140,6 @@ public:
     bool getFlagDecay() const;
 
     void writeNeuronSize(int neuronSize);
-    void writeTimeScale(double timeScale);
     void writeInhibitoryPortion(double inhibitoryPortion);
     void writeInhibitoryNeuronType(NeuronType inhibitoryNeuronType);
     void writeExcitatoryNeuronType(NeuronType excitatoryNeuronType);
@@ -158,7 +154,6 @@ public:
 
 signals:
     void neuronSizeChanged(int neuronSize);
-    void timeScaleChanged(double timeScale);
     void inhibitoryPortionChanged(double inhibitoryPortion);
     void inhibitoryNeuronTypeChanged(NeuronType inhibitoryNeuronType);
     void excitatoryNeuronTypeChanged(NeuronType excitatoryNeuronType);

--- a/autonomx/WolframCA.cpp
+++ b/autonomx/WolframCA.cpp
@@ -30,8 +30,9 @@ WolframCA::WolframCA(int id, GeneratorMeta * meta) : Generator(id, meta){
         qDebug() << "constructor (WolframCA):\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
     }
 
-    initialize();
+    timeScale = 95;
 
+    initialize();
 }
 
 WolframCA::~WolframCA() {
@@ -115,10 +116,8 @@ void WolframCA::computeIteration(double deltaTime) {
     else
         flag_randSeed=false;
 
-    int timeScale = getTimeScale();
-
     // every 1000 iterations, currentGeneration increments and iterationNumber resets
-    if(iterationNumber % (100-timeScale+1) == 0) {
+    if(iterationNumber % (100 - (int)(timeScale) + 1) == 0) {
         currentGeneration++;
         iterationNumber = 1;
     }
@@ -245,27 +244,6 @@ void WolframCA::writeRule(int rule) {
     // make sure you follow this signal structure when you write a property!
     emit ruleChanged(rule);
     emit valueChanged("rule", rule);
-}
-
-double WolframCA::getTimeScale() const {
-    return this->timeScale;
-}
-
-void WolframCA::writeTimeScale(double timeScale) {
-    if(this->timeScale == timeScale)
-        return;
-
-    if(flagDebug) {
-        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                    std::chrono::system_clock::now().time_since_epoch()
-        );
-
-        qDebug() << "writeTimeScale:\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
-    }
-
-    this->timeScale = timeScale;
-    emit valueChanged("timeScale", QVariant(timeScale));
-    emit timeScaleChanged(timeScale);
 }
 
 /*double WolframCA::getRandSeed() const {

--- a/autonomx/WolframCA.h
+++ b/autonomx/WolframCA.h
@@ -25,7 +25,6 @@ class WolframCA : public Generator
     Q_OBJECT
 
     Q_PROPERTY(int rule READ getRule WRITE writeRule NOTIFY ruleChanged)
-    Q_PROPERTY(int timeScale READ getTimeScale WRITE writeTimeScale NOTIFY timeScaleChanged)
     //Q_PROPERTY(double randSeed READ getRandSeed WRITE writeRandSeed NOTIFY randSeedChanged)
     Q_PROPERTY(bool flag_randSeed READ getFlagRandSeed WRITE writeFlagRandSeed NOTIFY flagRandSeedChanged)
 
@@ -52,9 +51,6 @@ private:
 
     //random generator to initialize cells
     std::mt19937 randomGenerator;
-
-    // timeScale variable
-    int timeScale = 95;
 
     // global iteration counter
     int iterationNumber;
@@ -85,9 +81,6 @@ public:
     int getRule();
     void writeRule(int rule);
 
-    void writeTimeScale(double timeScale);
-    double getTimeScale() const;
-
     //void writeRandSeed(double randSeed);
     //double getRandSeed() const;
 
@@ -97,7 +90,6 @@ public:
 signals:
     // QML signals
     void ruleChanged(int rule);
-    void timeScaleChanged(double timeScale);
     //void randSeedChanged(double randSeed);
     void flagRandSeedChanged(bool flag_randSeed);
 };

--- a/autonomx/components/racks/ParametersRack.qml
+++ b/autonomx/components/racks/ParametersRack.qml
@@ -14,6 +14,35 @@ ColumnLayout {
 
     signal changeContent()
 
+    // general
+    SubRack {
+        id: generalSubRack
+        subRackTitle: "General"
+
+        fields: [
+            NumberField {
+                labelText: "Width"
+                propName: "latticeWidth"
+                min: 1
+                max: 1000
+            },
+
+            NumberField {
+                labelText: "Height"
+                propName: "latticeHeight"
+                min: 1
+                max: 1000
+            },
+
+            SliderField {
+                labelText: "Time scale"
+                propName: "timeScale"
+                minVal: 1
+                maxVal: 100
+            }
+        ]
+    }
+
     Repeater {
         model: metaModel ? Object.keys(metaModel.fieldTree) : []
 

--- a/autonomx/generators/GameOfLife/meta.json
+++ b/autonomx/generators/GameOfLife/meta.json
@@ -5,43 +5,14 @@
 
     "racks": [
         {
-            "title": "General",
-            "fields": [
-                {
-                    "label": "Width",
-                    "propName": "latticeWidth",
-                    "type": "number",
-                    "min": 1,
-                    "max": 1000,
-                    "default": 20
-                },
-                {
-                    "label": "Height",
-                    "propName": "latticeHeight",
-                    "type": "number",
-                    "min": 1,
-                    "max": 1000,
-                    "default": 20
-                }
-            ]
-        },
-        {
             "title": "GameOfLife Properties",
             "fields": [
                 {
-                "label": "Pattern Type",
-                "propName": "GOLPattern",
-                "type": "select",
-                 "enumName": "GOLPatternType",
-                "default": 4
-                },
-                {
-                "label": "Time Scale",
-                "propName": "timeScale",
-                "type": "slider",
-                "min": 1,
-                "max": 100,
-                "default": 1
+                    "label": "Pattern Type",
+                    "propName": "GOLPattern",
+                    "type": "select",
+                     "enumName": "GOLPatternType",
+                    "default": 4
                 }
             ]
         }
@@ -59,12 +30,12 @@
     ],
 
     "enumLabels": {
-    "GOLPatternType": [
-    "Random",
-    "Glider",
-    "SpaceShip",
-    "RPentoMino",
-    "Pentadecathlon"
-    ]
-}
+        "GOLPatternType": [
+            "Random",
+            "Glider",
+            "SpaceShip",
+            "RPentoMino",
+            "Pentadecathlon"
+        ]
+    }
 }

--- a/autonomx/generators/SpikingNet/meta.json
+++ b/autonomx/generators/SpikingNet/meta.json
@@ -5,34 +5,6 @@
 
     "racks": [
         {
-            "title": "General",
-            "fields": [
-                {
-                    "label": "Width",
-                    "propName": "latticeWidth",
-                    "type": "number",
-                    "min": 1,
-                    "max": 1000,
-                    "default": 20
-                },
-                {
-                    "label": "Height",
-                    "propName": "latticeHeight",
-                    "type": "number",
-                    "min": 1,
-                    "max": 1000,
-                    "default": 20
-                },
-                {
-                    "label": "Time scale",
-                    "propName": "timeScale",
-                    "type": "slider",
-                    "max": 0.03,
-                    "default": 0.03
-                }
-            ]
-        },
-        {
             "title": "Neuron behavior",
             "fields": [
                 {

--- a/autonomx/generators/WolframCA/meta.json
+++ b/autonomx/generators/WolframCA/meta.json
@@ -5,27 +5,6 @@
 
     "racks": [
         {
-            "title": "General",
-            "fields": [
-                {
-                    "label": "Width",
-                    "propName": "latticeWidth",
-                    "type": "number",
-                    "min": 1,
-                    "max": 1000,
-                    "default": 20
-                },
-                {
-                    "label": "Height",
-                    "propName": "latticeHeight",
-                    "type": "number",
-                    "min": 1,
-                    "max": 1000,
-                    "default": 20
-                }
-            ]
-        },
-        {
             "title": "Wolfram Properties",
             "fields": [
                 {
@@ -35,14 +14,6 @@
                     "min": 0,
                     "max": 255,
                     "default": 102
-                },
-                {
-                    "label": "Time Scale",
-                    "propName": "timeScale",
-                    "type": "slider",
-                    "min": 1,
-                    "max": 100,
-                    "default": 1
                 },
                 {
                     "label": "Random Seed",

--- a/autonomx/layout/LatticeView.qml
+++ b/autonomx/layout/LatticeView.qml
@@ -14,7 +14,7 @@ Item {
     property int generatorIndex: window.activeGeneratorIndex
     property GeneratorRegionSet inputModel: generatorIndex < 0 ? null : generatorModel.at(generatorIndex).getInputRegionModel()
     property GeneratorRegionSet outputModel: generatorIndex < 0 ? null : generatorModel.at(generatorIndex).getOutputRegionModel()
-    property int ppc: 20            // pixels per cell, ie. how wide a cell square is in pixels. this is animated within QML (scaled by the zoom factor)
+    property int ppc: 10            // pixels per cell, ie. how wide a cell square is in pixels. this is animated within QML (scaled by the zoom factor)
 
     property QtObject currRegion: QtObject {
         property int type: -1


### PR DESCRIPTION
closes #301.

this PR also adds a small patch to the Parameters > General subrack for all generators so that it is no longer necessary to mention its field specs in every `meta.json` file, since they were mostly redundant. this also meant re-implementing timeScale as a Generator property.