### PR TITLE
add zoom and pan in the LatticeView

### DIFF
--- a/autonomx/GeneratorLattice.cpp
+++ b/autonomx/GeneratorLattice.cpp
@@ -55,6 +55,11 @@ float GeneratorLattice::getMaskAlpha() {
     return maskAlpha;
 }
 
+QVector2D GeneratorLattice::getPan()
+{
+    return pan;
+}
+
 void GeneratorLattice::writeSquareInPixels(float squareInPixels) {
     if(this->squareInPixels == squareInPixels) {
         return;
@@ -94,6 +99,18 @@ void GeneratorLattice::writeMaskAlpha(float maskAlpha) {
 
     this->maskAlpha = maskAlpha;
     emit maskAlphaChanged(maskAlpha);
+
+    // request a syncrhonize call to GeneratorLatticeRenderer
+    update();
+}
+
+void GeneratorLattice::writePan(QVector2D pan)
+{
+    if (this->pan == pan)
+        return;
+
+    this->pan = pan;
+    emit panChanged(pan);
 
     // request a syncrhonize call to GeneratorLatticeRenderer
     update();

--- a/autonomx/GeneratorLattice.h
+++ b/autonomx/GeneratorLattice.h
@@ -25,6 +25,7 @@ class GeneratorLattice : public QQuickFramebufferObject {
     Q_PROPERTY(float squareInPixels READ getSquareInPixels WRITE writeSquareInPixels NOTIFY squareInPixelsChanged)
     Q_PROPERTY(QVector4D mask READ getMask WRITE writeMask NOTIFY maskChanged)
     Q_PROPERTY(float maskAlpha READ getMaskAlpha WRITE writeMaskAlpha NOTIFY maskAlphaChanged)
+    Q_PROPERTY(QVector2D pan READ getPan WRITE writePan NOTIFY panChanged)
 public:
     GeneratorLattice();
     ~GeneratorLattice();
@@ -36,20 +37,24 @@ public:
     int getContainerHeightInPixels();
     QVector4D getMask();
     float getMaskAlpha();
+    QVector2D getPan();
 
     void writeGeneratorID(int generatorID);
     void writeSquareInPixels(float squareInPixels);
     void writeMask(QVector4D mask);
     void writeMaskAlpha(float maskAlpha);
+    void writePan(QVector2D pan);
 signals:
     void generatorIDChanged(int generatorID);
     void squareInPixelsChanged(float squareInPixels);
     void maskChanged(QVector4D mask);
     void maskAlphaChanged(float maskAlpha);
+    void panChanged(QVector2D pan);
 private:
     int generatorID;
-    float squareInPixels;       // uniform for pixel size of a lattice square
+    float squareInPixels;       // uniform for pixel size of a lattice square (aka zoom)
     QVector4D mask;             // uniform for mask shape (leftmost x, topmost y, width, height)
     float maskAlpha;            // uniform for mask alpha
+    QVector2D pan;              // uniform for lattice pan (managed in shader)
     bool flagDebug = false;
 };

--- a/autonomx/GeneratorLatticeRenderer.cpp
+++ b/autonomx/GeneratorLatticeRenderer.cpp
@@ -199,6 +199,7 @@ void GeneratorLatticeRenderer::render() {
 
         program->setUniformValue("mask", mask);
         program->setUniformValue("maskAlpha", maskAlpha);
+        program->setUniformValue("panInPixels", pan);
 
         program->setUniformValue("latticeWidthInSquares", *allocatedWidth);
         program->setUniformValue("latticeHeightInSquares", *allocatedHeight);
@@ -314,6 +315,7 @@ void GeneratorLatticeRenderer::synchronize(QQuickFramebufferObject *item) {
     squareInPixels = generatorLattice->getSquareInPixels();
     mask = generatorLattice->getMask();
     maskAlpha = generatorLattice->getMaskAlpha();
+    pan = generatorLattice->getPan();
 
     // update visible
     visible = item->isVisible();

--- a/autonomx/GeneratorLatticeRenderer.h
+++ b/autonomx/GeneratorLatticeRenderer.h
@@ -56,4 +56,5 @@ private:
     float squareInPixels;       // uniform for pixel size of a lattice square
     QVector4D mask;             // uniform for mask shape (leftmost x, topmost y, width, height)
     float maskAlpha;            // uniform for mask alpha
+    QVector2D pan;              // uniform for lattice pan
 };

--- a/autonomx/components/fields/AreaField.qml
+++ b/autonomx/components/fields/AreaField.qml
@@ -34,7 +34,6 @@ Field {
             // field frame events
             onHoveredChanged: fieldHovered = hovered
             onActiveFocusChanged: {
-                focusAlias =
                 window.editingTextField =
                 fieldFocused = activeFocus
             }

--- a/autonomx/components/fields/AreaField.qml
+++ b/autonomx/components/fields/AreaField.qml
@@ -34,7 +34,8 @@ Field {
             // field frame events
             onHoveredChanged: fieldHovered = hovered
             onActiveFocusChanged: {
-                window.editingTextField = activeFocus
+                focusAlias =
+                window.editingTextField =
                 fieldFocused = activeFocus
             }
 

--- a/autonomx/components/fields/Field.qml
+++ b/autonomx/components/fields/Field.qml
@@ -31,6 +31,8 @@ ColumnLayout {
     // TODO: implement this properly in the next sprint
     property bool hasError: false
 
+    property bool focusAlias
+
     // signals
     signal valueChanged(variant newValue)
     signal flagChanged(bool newFlag)
@@ -60,6 +62,7 @@ ColumnLayout {
     }
 
     Item {
+        // background
         Rectangle {
             anchors.fill: parent
             color: fieldBg
@@ -154,6 +157,17 @@ ColumnLayout {
 
                 visible: !field.activated
                 cursorShape: Qt.ForbiddenCursor
+            }
+        }
+
+        // border
+        Rectangle {
+            anchors.fill: parent
+            color: "transparent"
+            opacity: focusAlias ? 0.6 : 0
+            border {
+                width: 1
+                color: Stylesheet.colors.white
             }
         }
     }

--- a/autonomx/components/fields/Field.qml
+++ b/autonomx/components/fields/Field.qml
@@ -31,15 +31,24 @@ ColumnLayout {
     // TODO: implement this properly in the next sprint
     property bool hasError: false
 
-    property bool focusAlias
-
     // signals
     signal valueChanged(variant newValue)
     signal flagChanged(bool newFlag)
     signal errorReceived(string title, string errorText)
 
-    onValueChanged: if (target) target[propName] = newValue
-    onFlagChanged: if (target) target[flagName] = newFlag
+    // signal handlers
+    property var valueChangedHandler: function(newValue) {
+        if (target) target[propName] = newValue
+    }
+    property var flagChangedHandler: function(newFlag) {
+        if (target) taregt[flagName] = newFlag
+    }
+
+    // signal assigners
+    // this is so that handlers are always unique
+    // and can be overridden
+    onValueChanged: valueChangedHandler(newValue)
+    onFlagChanged: flagChangedHandler(newFlag)
 
     // layout
     Layout.preferredWidth: fieldWidth
@@ -164,7 +173,7 @@ ColumnLayout {
         Rectangle {
             anchors.fill: parent
             color: "transparent"
-            opacity: focusAlias ? 0.6 : 0
+            opacity: fieldFocused ? 0.6 : 0
             border {
                 width: 1
                 color: Stylesheet.colors.white

--- a/autonomx/components/fields/NumberField.qml
+++ b/autonomx/components/fields/NumberField.qml
@@ -10,6 +10,8 @@ Field {
     property string placeholder: ""
     property real defaultNum: propName && target ? target[propName] : 0
 
+    readonly property string fieldText: fieldFocused ? defaultNum : (unit ? defaultNum + unit : defaultNum)
+
     property bool unsigned: false   // when true: negative values allowed
     property int type: 0            // 0 = int; 1 = real
     property real min               // minimum accepted range value
@@ -43,6 +45,7 @@ Field {
 
     // this is essentially just a TextField with Int/Double validation
     // and fancy increment/decrement controls :)
+    // TODO: change to SpinBox
     fieldContent: TextField {
         id: fieldInput
 
@@ -50,13 +53,13 @@ Field {
         leftPadding: 0
 
         // text
-        text: activeFocus ? defaultNum : (unit ? defaultNum + unit : defaultNum)
+        text: type === 0 ? parseInt(fieldText, 10) : parseFloat(fieldText, 10)
         placeholderText: placeholder
 
         // background
         background: Item {}
 
-        validator: type === 0 ? intValidator : doubleValidator
+        validator: numberField.type === 0 ? intValidator : doubleValidator
 
         // interactivity
         selectByMouse: true
@@ -70,7 +73,6 @@ Field {
         // field frame
         onHoveredChanged: fieldHovered = hovered
         onActiveFocusChanged: {
-            focusAlias = activeFocus;
             window.editingTextField = activeFocus
             fieldFocused = activeFocus
         }

--- a/autonomx/components/fields/NumberField.qml
+++ b/autonomx/components/fields/NumberField.qml
@@ -15,7 +15,7 @@ Field {
     property real min               // minimum accepted range value
     property real max               // maximum accepted range value
     property real incStep: 1        // inc/dec widget step value
-    property string unit
+    property string unit            // non-editable suffix
 
     // inc/dec functions
     function increment() {
@@ -50,7 +50,7 @@ Field {
         leftPadding: 0
 
         // text
-        text: defaultNum
+        text: activeFocus ? defaultNum : (unit ? defaultNum + unit : defaultNum)
         placeholderText: placeholder
 
         // background
@@ -70,6 +70,7 @@ Field {
         // field frame
         onHoveredChanged: fieldHovered = hovered
         onActiveFocusChanged: {
+            focusAlias = activeFocus;
             window.editingTextField = activeFocus
             fieldFocused = activeFocus
         }

--- a/autonomx/components/fields/NumberField.qml
+++ b/autonomx/components/fields/NumberField.qml
@@ -15,6 +15,7 @@ Field {
     property real min               // minimum accepted range value
     property real max               // maximum accepted range value
     property real incStep: 1        // inc/dec widget step value
+    property string unit
 
     // inc/dec functions
     function increment() {

--- a/autonomx/components/fields/SelectField.qml
+++ b/autonomx/components/fields/SelectField.qml
@@ -25,7 +25,7 @@ Field {
         background: Item {}
 
         onActiveFocusChanged: {
-            focusAlias = activeFocus;
+            fieldFocused = activeFocus;
         }
 
         // options delegate

--- a/autonomx/components/fields/SelectField.qml
+++ b/autonomx/components/fields/SelectField.qml
@@ -24,6 +24,10 @@ Field {
 
         background: Item {}
 
+        onActiveFocusChanged: {
+            focusAlias = activeFocus;
+        }
+
         // options delegate
         delegate: ItemDelegate {
             id: itemDlgt

--- a/autonomx/components/fields/SliderField.qml
+++ b/autonomx/components/fields/SliderField.qml
@@ -57,7 +57,6 @@ Field {
         // field frame
         onHoveredChanged: fieldHovered = hovered
         onActiveFocusChanged: {
-            focusAlias = activeFocus
             window.editingTextField = activeFocus
             fieldFocused = activeFocus
         }

--- a/autonomx/components/fields/SliderField.qml
+++ b/autonomx/components/fields/SliderField.qml
@@ -57,6 +57,7 @@ Field {
         // field frame
         onHoveredChanged: fieldHovered = hovered
         onActiveFocusChanged: {
+            focusAlias = activeFocus
             window.editingTextField = activeFocus
             fieldFocused = activeFocus
         }

--- a/autonomx/components/fields/TextField.qml
+++ b/autonomx/components/fields/TextField.qml
@@ -24,7 +24,6 @@ Field {
         // field frame events
         onHoveredChanged: fieldHovered = hovered
         onActiveFocusChanged: {
-            focusAlias =
             window.editingTextField =
             fieldFocused = activeFocus
         }

--- a/autonomx/components/fields/TextField.qml
+++ b/autonomx/components/fields/TextField.qml
@@ -24,7 +24,8 @@ Field {
         // field frame events
         onHoveredChanged: fieldHovered = hovered
         onActiveFocusChanged: {
-            window.editingTextField = activeFocus
+            focusAlias =
+            window.editingTextField =
             fieldFocused = activeFocus
         }
 

--- a/autonomx/components/ui/DummyRegion.qml
+++ b/autonomx/components/ui/DummyRegion.qml
@@ -8,7 +8,7 @@ Rectangle {
 
     property int latticeWidth: regions.latticeWidth
     property int latticeHeight: regions.latticeHeight
-    property int ppc: latticeView.ppc
+    property real ppc: latticeView.ppc
 
     property point start
     property point end

--- a/autonomx/components/ui/Region.qml
+++ b/autonomx/components/ui/Region.qml
@@ -16,7 +16,7 @@ Control {
 
     property int latticeWidth: regions.latticeWidth
     property int latticeHeight: regions.latticeHeight
-    property int ppc: latticeView.ppc
+    property real ppc: latticeView.ppc
     property int type: 0                       // 0 = input; 1 = output
     property int resizeHitbox: 5            // zone padding
     property int area: rect.width * rect.height

--- a/autonomx/components/ui/Region.qml
+++ b/autonomx/components/ui/Region.qml
@@ -252,6 +252,8 @@ Control {
 
     // drag configuration
     onDragActiveChanged: {
+        latticeView.isDraggingRegion = dragActive;
+
         if (dragActive) {
             Drag.start();
             latticeView.switchSelectedRegion(type, index);
@@ -329,6 +331,8 @@ Control {
                 // unified cursor change on press/release
                 changeCursor(pressed ? cursorShape : null);
                 inEdit = pressed;
+
+                latticeView.isDraggingRegion = pressed;
 
                 // on mouse release
                 if (!pressed) snapToGrid("resize");

--- a/autonomx/components/ui/Region.qml
+++ b/autonomx/components/ui/Region.qml
@@ -100,8 +100,6 @@ Control {
 
     // snap to grid on drop / resize
     function snapToGrid(evtType) {
-        console.log("asdf")
-
         // clamp w/h when left corner/border dragged in the negatives
         var offsetW = 0, offsetH = 0;
         if (evtType === "resize") {
@@ -155,8 +153,13 @@ Control {
     // TODO: segment this into different functions
     // to limit calculation rate to what's necessary to calculate
     // (also find a way to only call matrix.setMask() once per mouse interaction)
+
+    // TODO: fix this
+    // this is called once for each region, on each zoom frame
+    // and essentially re-assigns mask to the last input every time
     function updateBounds() {
-        matrix.setMask(Qt.rect(x, y, width - 1, height - 1));
+        if (focus)
+            matrix.setMask(Qt.rect(x, y, width - 1, height - 1));
     }
 
     // force cursor on event

--- a/autonomx/components/util/PanManager.qml
+++ b/autonomx/components/util/PanManager.qml
@@ -25,6 +25,19 @@ Item {
     property real zoomCoarse: 100
     property real zoom: zoomCoarse
 
+    readonly property real maxZoom: 500
+    readonly property real minZoom: 10
+
+    // shortcut functions
+    function zoomIn(offset = 10) {
+        zoomCoarse += offset;
+        if (zoomCoarse >= maxZoom) zoomCoarse = maxZoom;
+    }
+    function zoomOut(offset = 10) {
+        zoomCoarse -= offset;
+        if (zoomCoarse <= minZoom) zoomCoarse = minZoom;
+    }
+
     // animations
     Behavior on easedPanX {
         enabled: !allowPan
@@ -103,13 +116,10 @@ Item {
 
             // increment or decrement zoom
             // TODO: adjust zoom inc/dec value by delta intensity
-            if (wheel.angleDelta.y > 0) {
-                zoomCoarse += offset;
-                if (zoomCoarse >= 500) zoomCoarse = 500;
-            } else {
-                zoomCoarse -= offset;
-                if (zoomCoarse <= 10) zoomCoarse = 10;
-            }
+            if (wheel.angleDelta.y > 0)
+                zoomIn(offset);
+            else
+                zoomOut(offset);
 
             // zoom according to mouse position
             // (Epic Formula TM in the Line Below)

--- a/autonomx/components/util/PanManager.qml
+++ b/autonomx/components/util/PanManager.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.12
 
 Item {
-    id: panDragger
+    id: panManager
     x: 0
     y: 0
     width: parent.width
@@ -12,7 +12,45 @@ Item {
 
     property vector2d dragValue: Qt.vector2d(x, y)
     property vector2d prevDragValue: Qt.vector2d(0, 0);
-    property bool allowPan: false
+    property bool allowPan: false       // used so that the pan doesn't snap back to (0, 0) on button release
+
+    // master props
+    property vector2d panCoarse: Qt.vector2d(panX, panY)
+    property vector2d pan: Qt.vector2d(easedPanX, easedPanY)
+    property real panX: 0
+    property real panY: 0
+    property real easedPanX: panX
+    property real easedPanY: panY
+    property real zoomCoarse: 100
+    property real zoom: zoomCoarse
+
+    // animations
+    Behavior on easedPanX {
+        enabled: !allowPan
+        SpringAnimation {
+            spring: 5
+            epsilon: 0.25
+            damping: 1
+            mass: 3
+        }
+    }
+    Behavior on easedPanY {
+        enabled: !allowPan
+        SpringAnimation {
+            spring: 5
+            epsilon: 0.25
+            damping: 1
+            mass: 3
+        }
+    }
+    Behavior on zoom {
+        SpringAnimation {
+            spring: 5
+            epsilon: 0.25
+            damping: 1
+            mass: 3
+        }
+    }
 
     onDragValueChanged: {
         if (allowPan) {
@@ -20,7 +58,8 @@ Item {
             var newDrag = prevDragValue.minus(dragValue);
 
             // add to pan value
-            latticeView.pan = latticeView.pan.plus(newDrag);
+            panX += newDrag.x;
+            panY += newDrag.y;
             // reset previous drag
             prevDragValue = dragValue;
         }
@@ -29,18 +68,19 @@ Item {
     MouseArea {
         id: panDragArea
         anchors.fill: parent
-        acceptedButtons: Qt.MiddleButton
+        acceptedButtons: Qt.MiddleButton        // because we middle only 8)
         preventStealing: true
 
+        // drag props
         drag.target: parent
         drag.threshold: 0
         drag.smoothed: false
 
+        // pan handling
         onPressed: {
             overrideCursor(Qt.ClosedHandCursor);
             parent.allowPan = true;
         }
-
         onReleased: {
             restoreCursor();
             parent.allowPan = false;
@@ -51,29 +91,31 @@ Item {
             parent.prevDragValue = Qt.vector2d(0, 0);
         }
 
-        // zoomies!!!!!! yeeeeehaaaaawwwwww
+        // zoom handling
         onWheel: {
             // get coords of mouse where the wheel evt was triggered
             // map to [-size/2, size/2] range
             let wheelDiff = Qt.vector2d(wheel.x, wheel.y).minus(Qt.vector2d(width / 2, height / 2));
+            let offset = 10;
 
             // increment or decrement zoom
             // TODO: adjust zoom inc/dec value by delta intensity
             if (wheel.angleDelta.y > 0) {
-                zoomPercent += 5;
-                if (zoomPercent >= 500) zoomPercent = 500;
+                zoomCoarse += offset;
+                if (zoomCoarse >= 500) zoomCoarse = 500;
             } else {
-                zoomPercent -= 5;
-                if (zoomPercent <= 10) zoomPercent = 10;
+                zoomCoarse -= offset;
+                if (zoomCoarse <= 10) zoomCoarse = 10;
             }
 
             // zoom according to mouse position
             // (Epic Formula TM in the Line Below)
-            wheelDiff = wheelDiff.plus(latticeView.pan).times(0.05 * (1 / zoom));
+            wheelDiff = wheelDiff.plus(panCoarse).times(offset / zoomCoarse);
             if (wheel.angleDelta.y < 0) wheelDiff = wheelDiff.times(-1);
 
             // add to global pan vector
-            latticeView.pan = latticeView.pan.plus(wheelDiff);
+            panX += wheelDiff.x;
+            panY += wheelDiff.y;
         }
     }
 }

--- a/autonomx/components/util/PanManager.qml
+++ b/autonomx/components/util/PanManager.qml
@@ -1,0 +1,63 @@
+import QtQuick 2.12
+
+Item {
+    id: panDragger
+    x: 0
+    y: 0
+    width: parent.width
+    height: parent.height
+    enabled: !(generatorIndex < 0)
+
+    Drag.active: panDragArea.drag.active
+
+    property vector2d dragValue: Qt.vector2d(x, y)
+    property vector2d prevDragValue: Qt.vector2d(0, 0);
+    property bool allowPan: false
+
+    onDragValueChanged: {
+        if (allowPan) {
+            // calculate difference
+            var newDrag = prevDragValue.minus(dragValue);
+
+            // add to pan value
+            latticeView.pan = latticeView.pan.plus(newDrag);
+            // reset previous drag
+            prevDragValue = dragValue;
+        }
+    }
+
+    MouseArea {
+        id: panDragArea
+        anchors.fill: parent
+        acceptedButtons: Qt.MiddleButton
+        preventStealing: true
+
+        drag.target: parent
+        drag.threshold: 0
+        drag.smoothed: false
+
+        onPressed: {
+            overrideCursor(Qt.ClosedHandCursor);
+            parent.allowPan = true;
+        }
+
+        onReleased: {
+            restoreCursor();
+            parent.allowPan = false;
+
+            // reinitialize drag values
+            parent.x = 0
+            parent.y = 0
+            parent.prevDragValue = Qt.vector2d(0, 0);
+        }
+
+        // zoomies!!!!!! yeeeeehaaaaawwwwww
+        onWheel: {
+            // TODO: adjust zoom inc/dec value by delta intensity
+            if (wheel.angleDelta.y > 0)
+                zoom += 0.1;
+            else
+                zoom -= 0.1;
+        }
+    }
+}

--- a/autonomx/components/util/PanManager.qml
+++ b/autonomx/components/util/PanManager.qml
@@ -12,7 +12,8 @@ Item {
 
     property vector2d dragValue: Qt.vector2d(x, y)
     property vector2d prevDragValue: Qt.vector2d(0, 0);
-    property bool allowPan: false       // used so that the pan doesn't snap back to (0, 0) on button release
+    property bool allowPan: false               // used so that the pan doesn't snap back to (0, 0) on button release
+    property bool isDraggingRegion: false       // changed by Region dragging and/or resizing
 
     // master props
     property vector2d panCoarse: Qt.vector2d(panX, panY)
@@ -53,16 +54,16 @@ Item {
     }
 
     onDragValueChanged: {
-        if (allowPan) {
-            // calculate difference
-            var newDrag = prevDragValue.minus(dragValue);
+        if (!allowPan || isDraggingRegion) return;
 
-            // add to pan value
-            panX += newDrag.x;
-            panY += newDrag.y;
-            // reset previous drag
-            prevDragValue = dragValue;
-        }
+        // calculate difference
+        var newDrag = prevDragValue.minus(dragValue);
+
+        // add to pan value
+        panX += newDrag.x;
+        panY += newDrag.y;
+        // reset previous drag
+        prevDragValue = dragValue;
     }
 
     MouseArea {
@@ -93,6 +94,8 @@ Item {
 
         // zoom handling
         onWheel: {
+            if (isDraggingRegion) return;
+
             // get coords of mouse where the wheel evt was triggered
             // map to [-size/2, size/2] range
             let wheelDiff = Qt.vector2d(wheel.x, wheel.y).minus(Qt.vector2d(width / 2, height / 2));

--- a/autonomx/components/util/PanManager.qml
+++ b/autonomx/components/util/PanManager.qml
@@ -53,11 +53,27 @@ Item {
 
         // zoomies!!!!!! yeeeeehaaaaawwwwww
         onWheel: {
+            // get coords of mouse where the wheel evt was triggered
+            // map to [-size/2, size/2] range
+            let wheelDiff = Qt.vector2d(wheel.x, wheel.y).minus(Qt.vector2d(width / 2, height / 2));
+
+            // increment or decrement zoom
             // TODO: adjust zoom inc/dec value by delta intensity
-            if (wheel.angleDelta.y > 0)
-                zoom += 0.1;
-            else
-                zoom -= 0.1;
+            if (wheel.angleDelta.y > 0) {
+                zoomPercent += 5;
+                if (zoomPercent >= 500) zoomPercent = 500;
+            } else {
+                zoomPercent -= 5;
+                if (zoomPercent <= 10) zoomPercent = 10;
+            }
+
+            // zoom according to mouse position
+            // (Epic Formula TM in the Line Below)
+            wheelDiff = wheelDiff.plus(latticeView.pan).times(0.05 * (1 / zoom));
+            if (wheel.angleDelta.y < 0) wheelDiff = wheelDiff.times(-1);
+
+            // add to global pan vector
+            latticeView.pan = latticeView.pan.plus(wheelDiff);
         }
     }
 }

--- a/autonomx/components/util/ShortcutManager.qml
+++ b/autonomx/components/util/ShortcutManager.qml
@@ -31,6 +31,7 @@ Item {
     }
 
     // zoom
+    // Ctrl = Cmd
     Shortcut {
         sequence: "Ctrl+="
         onActivated: latticeView.zoomIn()
@@ -40,7 +41,7 @@ Item {
         onActivated: latticeView.zoomOut()
     }
     Shortcut {
-        sequence: "Shift+0"
+        sequence: "Ctrl+0"
         onActivated: latticeView.resetView()
     }
 

--- a/autonomx/components/util/ShortcutManager.qml
+++ b/autonomx/components/util/ShortcutManager.qml
@@ -33,16 +33,15 @@ Item {
     // zoom
     Shortcut {
         sequence: "Ctrl+="
-        onActivated: {
-            latticeView.zoomIn();
-        }
+        onActivated: latticeView.zoomIn()
     }
-
     Shortcut {
         sequence: "Ctrl+-"
-        onActivated: {
-            latticeView.zoomOut();
-        }
+        onActivated: latticeView.zoomOut()
+    }
+    Shortcut {
+        sequence: "Shift+0"
+        onActivated: latticeView.resetView()
     }
 
     // lattice view

--- a/autonomx/components/util/ShortcutManager.qml
+++ b/autonomx/components/util/ShortcutManager.qml
@@ -30,6 +30,21 @@ Item {
         }
     }
 
+    // zoom
+    Shortcut {
+        sequence: "Ctrl+="
+        onActivated: {
+            latticeView.zoomIn();
+        }
+    }
+
+    Shortcut {
+        sequence: "Ctrl+-"
+        onActivated: {
+            latticeView.zoomOut();
+        }
+    }
+
     // lattice view
     Shortcut {
         sequence: "Alt+I"

--- a/autonomx/layout/LatticeView.qml
+++ b/autonomx/layout/LatticeView.qml
@@ -19,13 +19,13 @@ Item {
 
     // pan/zoom properties
     property real ppc: 10 * zoom            // pixels per cell, ie. how wide a cell square is in pixels. this is animated within QML (scaled by the zoom factor)
-    property real zoom: 1
-    property real prevZoom: 1
+    property real zoom: zoomPercent / 100
+    property real zoomPercent: 100
     property vector2d pan: Qt.vector2d(0, 0)
 
-    Behavior on ppc {
-        SmoothedAnimation { velocity: 1000 }
-    }
+//    Behavior on ppc {
+//        SmoothedAnimation { velocity: 1000 }
+//    }
 
     property QtObject currRegion: QtObject {
         property int type: -1
@@ -375,6 +375,9 @@ Item {
 
         fieldWidth: 100
         labelText: "Zoom"
-        defaultNum: 100
+        incStep: 5
+
+        target: latticeView
+        propName: "zoomPercent"
     }
 }

--- a/autonomx/layout/LatticeView.qml
+++ b/autonomx/layout/LatticeView.qml
@@ -74,6 +74,14 @@ Item {
         if (currRegion.type < 0) return;
     }
 
+    // zoom
+    function zoomIn() {
+        panManager.zoomIn();
+    }
+    function zoomOut() {
+        panManager.zoomOut();
+    }
+
     // add region
     function addNewInput() {
         switchSelectedRegion(0, inputModel.rowCount(), true);

--- a/autonomx/layout/LatticeView.qml
+++ b/autonomx/layout/LatticeView.qml
@@ -18,10 +18,10 @@ Item {
     property GeneratorRegionSet outputModel: generatorIndex < 0 ? null : generatorModel.at(generatorIndex).getOutputRegionModel()
 
     // pan/zoom properties
-    property real ppc: 10 * zoom            // pixels per cell, ie. how wide a cell square is in pixels. this is animated within QML (scaled by the zoom factor)
-    property real zoom: zoomPercent / 100
-    property real zoomPercent: 100
-    property vector2d pan: Qt.vector2d(0, 0)
+    property real ppc: 0.1 * zoom               // pixels per cell, ie. how wide a cell square is in pixels. this is animated within QML (scaled by the zoom factor)
+    property alias zoom: panManager.zoom        // in percents
+    property alias zoomCoarse: panManager.zoomCoarse
+    property alias pan: panManager.pan          // in pixels
 
 //    Behavior on ppc {
 //        SmoothedAnimation { velocity: 1000 }
@@ -170,7 +170,9 @@ Item {
     }
 
     // pan and zoom area
-    PanManager {}
+    PanManager {
+        id: panManager
+    }
 
     // I/O regions
     Item {
@@ -378,6 +380,6 @@ Item {
         incStep: 5
 
         target: latticeView
-        propName: "zoomPercent"
+        propName: "zoomCoarse"
     }
 }

--- a/autonomx/layout/LatticeView.qml
+++ b/autonomx/layout/LatticeView.qml
@@ -74,13 +74,10 @@ Item {
         if (currRegion.type < 0) return;
     }
 
-    // zoom
-    function zoomIn() {
-        panManager.zoomIn();
-    }
-    function zoomOut() {
-        panManager.zoomOut();
-    }
+    // PanManager function aliases
+    property var zoomIn: panManager.zoomIn
+    property var zoomOut: panManager.zoomOut
+    property var resetView: panManager.resetView
 
     // add region
     function addNewInput() {
@@ -387,5 +384,12 @@ Item {
 
         target: latticeView
         propName: "zoomCoarse"
+
+        // override this because we want to change the exponent here
+        valueChangedHandler: function(newValue) {
+            if (target) {
+                panManager.zoomExp = Math.log2(newValue / 100);
+            }
+        }
     }
 }

--- a/autonomx/layout/LatticeView.qml
+++ b/autonomx/layout/LatticeView.qml
@@ -365,6 +365,7 @@ Item {
     NumberField {
         id: zoomField
         visible: !(generatorIndex < 0)
+        unit: "%"
 
         anchors {
             left: parent.left
@@ -372,7 +373,7 @@ Item {
             margins: 20
         }
 
-        fieldWidth: 100
+        fieldWidth: 120
         labelText: "Zoom"
         incStep: 5
 

--- a/autonomx/layout/LatticeView.qml
+++ b/autonomx/layout/LatticeView.qml
@@ -22,10 +22,7 @@ Item {
     property alias zoom: panManager.zoom        // in percents
     property alias zoomCoarse: panManager.zoomCoarse
     property alias pan: panManager.pan          // in pixels
-
-//    Behavior on ppc {
-//        SmoothedAnimation { velocity: 1000 }
-//    }
+    property alias isDraggingRegion: panManager.isDraggingRegion
 
     property QtObject currRegion: QtObject {
         property int type: -1

--- a/autonomx/main.qml
+++ b/autonomx/main.qml
@@ -42,7 +42,6 @@ ApplicationWindow {
     property bool spacePressed: false
     property bool editingTextField: false
     property alias allowSlideDrag: slideDragger.visible
-    property alias allowPanDrag: panDragger.visible
 
     // saving stuff
     property alias saveManager: saveManager
@@ -202,40 +201,6 @@ ApplicationWindow {
 
             onReleased: {
                 window.allowSlideDrag = false
-                parent.x = 0
-                parent.y = 0
-            }
-        }
-    }
-
-    // slide drag detection/mgmt
-    Item {
-        id: panDragger
-        x: 0
-        y: 0
-        width: parent.width
-        height: parent.height
-        visible: false
-
-        property alias mouseArea: panDragArea
-        Drag.active: panDragArea.drag.active
-
-        MouseArea {
-            id: panDragArea
-            anchors.fill: parent
-
-            drag.target: parent
-            drag.threshold: 0
-            drag.smoothed: false
-
-            onPressed: {
-                overrideCursor(Qt.ClosedHandCursor);
-            }
-
-            onReleased: {
-                restoreCursor();
-
-                window.allowPanDrag = false
                 parent.x = 0
                 parent.y = 0
             }

--- a/autonomx/qml.qrc
+++ b/autonomx/qml.qrc
@@ -78,5 +78,6 @@
         <file>generators/GameOfLife/meta.json</file>
         <file>generators/README.md</file>
         <file>components/ui/OscSettings.qml</file>
+        <file>components/util/PanManager.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
closes #315 ; closes #316 

users can now pan (by middle-mouse clicking) and zoom (by middle-mouse wheeling) inside the lattice view. a new field was also implemented to track and edit the zoom value on the fly.

additionally, some shortcuts were added:
- Ctrl + = (equal sign): zoom in
- Ctrl + - (minus sign): zoom out
- Ctrl + 0: reset view (pan [0, 0]; zoom 100%)