### PR TITLE
link application constants to appropriate GUI locations

### DIFF
--- a/autonomx/Settings.cpp
+++ b/autonomx/Settings.cpp
@@ -1,0 +1,9 @@
+#include "Settings.h"
+
+Settings::Settings(QObject* parent) : QSettings(parent) {}
+Settings::~Settings() {}
+
+QVariant Settings::value(const QString &key, const QVariant &defaultValue)
+{
+    return QSettings::value(key, defaultValue);
+}

--- a/autonomx/Settings.cpp
+++ b/autonomx/Settings.cpp
@@ -3,7 +3,7 @@
 Settings::Settings(QObject* parent) : QSettings(parent) {}
 Settings::~Settings() {}
 
-QVariant Settings::value(const QString &key, const QVariant &defaultValue)
+QVariant Settings::value(const QString &key, const QVariant &defaultValue = QVariant())
 {
     return QSettings::value(key, defaultValue);
 }

--- a/autonomx/Settings.h
+++ b/autonomx/Settings.h
@@ -1,0 +1,32 @@
+// Copyright 2020, Xmodal
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <QSettings>
+
+// this is a wrapper for QSettings to make it exposable in QML
+// all it does is make the value method invokable;
+// you still can't add settings from within QML. that has to (and should) be done in main.cpp
+// or anywhere in the backend, really
+class Settings : public QSettings
+{
+    Q_OBJECT
+public:
+    Settings(QObject *parent = 0);
+    virtual ~Settings();
+
+    Q_INVOKABLE QVariant value(const QString &key, const QVariant &defaultValue);
+};

--- a/autonomx/autonomx.pro
+++ b/autonomx/autonomx.pro
@@ -50,6 +50,7 @@ SOURCES += \
     Izhikevich.cpp \
     OscEngine.cpp \
     OscEngineFacade.cpp \
+    Settings.cpp \
     SpikingNet.cpp \
     WolframCA.cpp \
     main.cpp
@@ -106,6 +107,7 @@ HEADERS += \
     NeuronType.h \
     OscEngine.h \
     OscEngineFacade.h \
+    Settings.h \
     SpikingNet.h \
     WolframCA.h
 

--- a/autonomx/components/ui/OscSettings.qml
+++ b/autonomx/components/ui/OscSettings.qml
@@ -153,7 +153,7 @@ Item {
                 Layout.bottomMargin: 15
 
                 Label {
-                    text: "autonomX\nby Xmodal"
+                    text: Qt.application.name + "\nby " + Qt.application.organization
                     lineHeight: 1
                     font {
                         family: "Archivo"
@@ -164,7 +164,7 @@ Item {
                 Item { Layout.fillWidth: true }
 
                 Label {
-                    text: "version 0.1.0\n22-09-2020"
+                    text: "version " + Qt.application.version + "\n" + settings.value("global/releaseDate", "n/a")
                     lineHeight: 1
                     horizontalAlignment: Text.AlignRight
                     font {

--- a/autonomx/components/ui/OscSettings.qml
+++ b/autonomx/components/ui/OscSettings.qml
@@ -164,9 +164,10 @@ Item {
                 Item { Layout.fillWidth: true }
 
                 Label {
-                    text: "version " + Qt.application.version + "\n" + settings.value("global/releaseDate", "n/a")
+                    text: "version " + Qt.application.version
                     lineHeight: 1
                     horizontalAlignment: Text.AlignRight
+                    Layout.alignment: Qt.AlignBottom
                     font {
                         family: "Archivo"
                         pixelSize: 10

--- a/autonomx/components/util/SaveManager.qml
+++ b/autonomx/components/util/SaveManager.qml
@@ -6,6 +6,7 @@ Item {
 
     property string currentFileUri
     property string currentFileName: basename(currentFileUri)
+    property string extensionName: settings.value("global/extensionName", "")
 
     function basename(str) {
         return (str.slice(str.lastIndexOf("/")+1));

--- a/autonomx/main.cpp
+++ b/autonomx/main.cpp
@@ -22,6 +22,7 @@
 #include <QFontDatabase>
 #include <QQmlPropertyMap>
 #include <QFile>
+#include <QSettings>
 
 #include "OscEngine.h"
 #include "ComputeEngine.h"
@@ -36,6 +37,7 @@
 #include "GameOfLife.h"
 #include "AppModel.h"
 #include "CursorOverrider.h"
+#include "Settings.h"
 
 // only include AppNap code if platform is macOS
 #ifdef Q_OS_MAC
@@ -56,6 +58,7 @@ int main(int argc, char *argv[]) {
     // constant settings
     const char* applicationName = "autonomX";
     const char* applicationVersion = "0.1.1";
+    const char* applicationReleaseDate = "22-09-2020";
     const char* organizationName = "Xmodal";
     const char* extensionName = "atnx";
 
@@ -63,6 +66,9 @@ int main(int argc, char *argv[]) {
     QCoreApplication::setApplicationName(applicationName);
     QCoreApplication::setApplicationVersion(applicationVersion);
     QCoreApplication::setOrganizationName(organizationName);
+
+    Settings* settings = new Settings();
+    settings->setValue("global/releaseDate", applicationReleaseDate);
 
 
     // load fonts in the project database
@@ -114,6 +120,7 @@ int main(int argc, char *argv[]) {
     qmlEngine.rootContext()->setContextProperty("generatorMetaModel", AppModel::getInstance().getGeneratorMetaModel().data());
     qmlEngine.rootContext()->setContextProperty("oscEngine", AppModel::getInstance().getOscEngineFacade().data());
     qmlEngine.rootContext()->setContextProperty("extensionName", extensionName);
+    qmlEngine.rootContext()->setContextProperty("settings", settings);
     qmlEngine.load(QUrl(QStringLiteral("qrc:/main.qml")));
     if (qmlEngine.rootObjects().isEmpty())
         return -1;

--- a/autonomx/main.cpp
+++ b/autonomx/main.cpp
@@ -58,7 +58,6 @@ int main(int argc, char *argv[]) {
     // constant settings
     const char* applicationName = "autonomX";
     const char* applicationVersion = "0.1.1";
-    const char* applicationReleaseDate = "22-09-2020";
     const char* organizationName = "Xmodal";
     const char* extensionName = "atnx";
 
@@ -68,7 +67,7 @@ int main(int argc, char *argv[]) {
     QCoreApplication::setOrganizationName(organizationName);
 
     Settings* settings = new Settings();
-    settings->setValue("global/releaseDate", applicationReleaseDate);
+    settings->setValue("global/extensionName", extensionName);
 
 
     // load fonts in the project database
@@ -119,7 +118,6 @@ int main(int argc, char *argv[]) {
     qmlEngine.rootContext()->setContextProperty("generatorModel", AppModel::getInstance().getGeneratorModel().data());
     qmlEngine.rootContext()->setContextProperty("generatorMetaModel", AppModel::getInstance().getGeneratorMetaModel().data());
     qmlEngine.rootContext()->setContextProperty("oscEngine", AppModel::getInstance().getOscEngineFacade().data());
-    qmlEngine.rootContext()->setContextProperty("extensionName", extensionName);
     qmlEngine.rootContext()->setContextProperty("settings", settings);
     qmlEngine.load(QUrl(QStringLiteral("qrc:/main.qml")));
     if (qmlEngine.rootObjects().isEmpty())

--- a/autonomx/main.qml
+++ b/autonomx/main.qml
@@ -54,7 +54,7 @@ ApplicationWindow {
     visible: true
     width: 1440
     height: 810
-    title: (currentFileName.length > 0 ? "[" + currentFileName + "] " : "") + Qt.application.name + " " + Qt.application.version
+    title: (currentFileName.length > 0 ? "[" + currentFileName + "] " : "") + Qt.application.name + " - version " + Qt.application.version
 
     function toggleFullscreen() {
         if (visibility === Window.FullScreen) {


### PR DESCRIPTION
closes #86 

the credentials found in the OSC (a.k.a global) settings dropdown are now linked to their backend, static counterparts defined in `main.cpp`. as a bonus, a `QSettings` wrapper was implemented to allow for further application settings to be defined and accessed through QML.