### PR TITLE
357 format output osc messages

### DIFF
--- a/autonomx/OscEngine.cpp
+++ b/autonomx/OscEngine.cpp
@@ -149,7 +149,7 @@ void OscEngine::sendOscData(int generatorId, QVariantList data) {
     }
 
     QSharedPointer<OscSender> sender = oscSenders.value(generatorId);
-    sender->send(oscReceiverAddress, data);
+    sender->send(data);
 }
 
 void OscEngine::createOscReceiver(int generatorId, QString address, int port) {

--- a/qosc/OscSender.cpp
+++ b/qosc/OscSender.cpp
@@ -53,13 +53,13 @@ void OscSender::setOscSenderHost(const QString& host)
     m_udpSocket->connectToHost(m_hostAddress , m_port);
 }
 
-void OscSender::send(const QString& oscAddress, const QVariantList& arguments) {
+void OscSender::send(const QVariantList& arguments) {
     if(flagDebug) {
         qDebug() << "send (OscSender)\targuments = " << arguments;
     }
 
     QByteArray datagram;
-    this->variantListToByteArray(datagram, oscAddress, arguments);
+    this->variantListToByteArray(datagram, arguments);
 
     qint64 written = m_udpSocket->write(datagram);
 
@@ -71,13 +71,14 @@ void OscSender::send(const QString& oscAddress, const QVariantList& arguments) {
 }
 
 
-void OscSender::variantListToByteArray(QByteArray& outputResult, const QString& oscAddress, const QVariantList& arguments) {
+void OscSender::variantListToByteArray(QByteArray& outputResult, const QVariantList& arguments) {
     char buffer[1024];
     osc::OutboundPacketStream packet(buffer, 1024);
     // FIXME: Sending datagrams larger than 512 bytes is in general disadvised, as even if they are sent successfully,
     // they are likely to be fragmented by the IP layer before arriving at their final destination.
     // packet << osc::BeginBundleImmediate << osc::BeginMessage(oscAddress.toStdString().c_str());
-    packet << osc::BeginMessage(oscAddress.toStdString().c_str());
+    QString loadString = "";
+    packet << osc::BeginMessage(loadString.toStdString().c_str());
 
     for (int i = 0; i < arguments.count(); ++ i) {
         QVariant argument = arguments[i];

--- a/qosc/OscSender.h
+++ b/qosc/OscSender.h
@@ -39,7 +39,7 @@ public:
      * @param oscAddress OSC path /like/this
      * @param arguments List of QVariant arguments of any type
      */
-    Q_INVOKABLE void send(const QString& oscAddress, const QVariantList& arguments);
+    Q_INVOKABLE void send(const QVariantList& arguments);
 
 signals:
     // TODO: Add messageSent signal
@@ -52,7 +52,7 @@ private:
     QHostAddress m_hostAddress;
     quint16 m_port;
 
-    void variantListToByteArray(QByteArray& outputResult, const QString& oscAddress, const QVariantList& arguments);
+    void variantListToByteArray(QByteArray& outputResult, const QVariantList& arguments);
 
     bool flagDebug = false;
 };


### PR DESCRIPTION
Final fixes to OSC messaging system.

Erroneous "/input" string has been removed from output OSC messages.
Fixed small bugs that caused extra / incorrect error messages to be printed to the console when an invalid OSC input message was received.