### PR TITLE
add SVG plugin to autonomx.pro

### DIFF
--- a/autonomx/autonomx.pro
+++ b/autonomx/autonomx.pro
@@ -2,6 +2,7 @@ QT += quick
 QT += core
 QT += qml
 QT += gui
+QT += svg
 # QT += serialport
 CONFIG += c++17
 


### PR DESCRIPTION
adds a single line to autonomx.pro to include the SVG plugin on build. this is mandatory for Mac OS builds, because apparently the lib isn't packaged out-of-the-box (unlike on Windows).